### PR TITLE
Write dimension, fact dataframes to postgres tables

### DIFF
--- a/db_tools.py
+++ b/db_tools.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python
+# See https://medium.com/analytics-vidhya/part-4-pandas-dataframe-to-postgresql-using-python-8ffdb0323c09
+# https://github.com/Muhd-Shahid/Learn-Python-Data-Access/tree/main/PostgreSQL
+
+import pandas as pd
+import psycopg2 as pg
+from psycopg2.extras import execute_values
+import sys
+
+# DBC Class connects to postgres database with methods for executing different sql commands
+class DBC:
+    def __init__(self, db_config):
+        self.config = db_config
+        try:
+            self.conn = pg.connect(**db_config)
+        except pg.DatabaseError as e:
+            print(f"Unable to connect to database:\n{e}")
+            sys.exit(1)
+            
+    def close_connection(self):
+        self.conn.close()
+
+    def execute_query(self, query, close=False):    
+        with self.conn as conn, conn.cursor() as curs:
+            curs.execute(query)
+        if close:
+            self.close_connection()      
+            
+    def delete_schema(self, schema, option="Restrict", close=False):
+        """Delete schema. Option can be "Cascade" or "Restrict" (default):
+        https://www.postgresql.org/docs/14/sql-dropschema.html
+        """
+        self.execute_query(f"DROP SCHEMA IF EXISTS {schema} {option}", close=close)
+        
+    def create_schema(self, schema, replace=False, close=False):
+        """Create schema.
+        https://www.postgresql.org/docs/14/sql-createschema.html
+        """
+        if replace:
+            self.delete_schema(schema, option="Cascade")
+        self.execute_query(f"CREATE SCHEMA IF NOT EXISTS {schema}", close=close)
+    
+    def delete_table(self, schema, table_name, option="Restrict", close=False):
+        """Delete table in schema. Option can be "Cascade" or "Restrict" (default):
+        https://www.postgresql.org/docs/14/sql-droptable.html
+        """
+        self.execute_query(f"DROP TABLE IF EXISTS {schema}.{table_name} {option}", close=close)
+
+    def create_table(self, schema, table_name, table_columns, replace=False, close=False):
+        """Create schema. table columns is a list of tuples, with each tuple containing
+        two strings: the first defines the column name and the second the column's type
+        https://www.postgresql.org/docs/14/sql-createtable.html
+        """
+        column_str = ", ".join(map(" ".join, table_columns))
+        if replace:
+            self.delete_table(schema, table_name, option="Cascade")
+        self.execute_query(f"CREATE TABLE IF NOT EXISTS {schema}.{table_name} ({column_str})", close=close)
+        
+    def copy_csv_to_table(self, schema, table_name, csv_path, header=False, close=False):
+        if not header:
+            header_str = " CSV HEADER"
+        self.execute_query(f"COPY {schema}.{table_name} FROM '{csv_path}' DELIMITER ','{header_str}", close=close)
+        
+    def insert_df_into_table(self, schema, table_name, df, close=False, **kwargs):
+        if len(df) > 0:
+            columns = ",".join(list(df.columns))
+            insert_stmt = f"INSERT INTO {schema}.{table_name} ({columns}) VALUES %s"
+            with self.conn as conn, conn.cursor() as cur:
+                execute_values(cur, insert_stmt, df.values, **kwargs)
+        else:
+            print("Input dataframe, df, is empty: No data was written to the database!")
+        if close:
+            self.close_connection()   
+        
+    def select_query_to_df(self, query, close=False):
+        """Execute input SQL query using pandas.read_sql and return resulting table as a dataframe.
+        """
+        df = pd.read_sql(query, self.conn)
+        if close:
+            self.close_connection()         
+        return df

--- a/step1_electoral_college_data.ipynb
+++ b/step1_electoral_college_data.ipynb
@@ -16,7 +16,7 @@
     "    4. Scrape each Election Year's web page to download the two tables containing all Election Data\n",
     "    5. Parse the Data for All Election Years into a useable, compact format\n",
     "    6. Validate Accuracy of Parsed Election Data\n",
-    "3. [ ] Transform and Validate Parsed Election Data so that it conforms to a Star Schema design pattern, with Candidate and State Dimension Tables and Electoral Vote Fact table:\n",
+    "3. [X] Transform and Validate Parsed Election Data so that it conforms to a Star Schema design pattern, with Candidate and State Dimension Tables and Electoral Vote Fact table:\n",
     "    1. Spot Check Parsed Data for Individual Election Years\n",
     "    2. Transform and Validate Candidate Data\n",
     "    3. Transform and Validate State Data\n",
@@ -54,7 +54,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1516,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -77,7 +77,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 369,
+   "execution_count": 252,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -224,6 +224,23 @@
     "    else:\n",
     "        return (None, None)\n",
     "\n",
+    "def create_tables_from_dfs(dbc, schema, table_names, table_column_defs, dfs, replace=True, close=False):\n",
+    "    \"\"\"This function builds a new schema, schema, in a postgres db using the\n",
+    "    input psycopg2 connection class instance, dbc, then builds one or more tables\n",
+    "    with each table's name specified in the list, table_names, using eac table\n",
+    "    table column definition specified in the list, table_column_defs, and finally\n",
+    "    populates eac table with the data from the list of dataframes, dfs.\n",
+    "    \"\"\"\n",
+    "    print(f\"Creating Schema: {schema}\")\n",
+    "    dbc.create_schema(schema, replace=replace)\n",
+    "    for t_ind, t_name in enumerate(table_names):\n",
+    "        print(f\"Creating Table: {schema}.{t_name}\")\n",
+    "        dbc.create_table(schema, t_name, table_column_defs[t_ind], replace=replace)\n",
+    "        dbc.insert_df_into_table(schema, t_name, dfs[t_ind])\n",
+    "    print(\"All Data Successfully Inserted!!!\")\n",
+    "    if close:\n",
+    "        dbc.close_connection()\n",
+    "\n",
     "def make_map_usa(df, col2plot, figsize=(15,8), title=None, fontsize=18, cmap='Blues', edgecolor='k'):\n",
     "    # Define fixed longitude limit, xlim, and latitude limit, ylim, for USA\n",
     "    xlim = (-172, -58)\n",
@@ -282,7 +299,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 127,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -419,14 +436,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 126,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Data is available from the National Archives website for the following election years:\n",
+      "Data is currently available from the National Archives website for the following election years:\n",
       "1892, 1896, 1900, 1904, 1908, 1912, 1916, 1920, 1924, 1928, 1932, 1936, 1940, 1944, 1948, 1952, 1956, 1960, 1964, 1968, 1972, 1976, 1980, 1984, 1988, 1992, 1996, 2000, 2004, 2008, 2012, 2016, 2020\n"
      ]
     }
@@ -445,7 +462,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 370,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -515,75 +532,80 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 558,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Election Year: 1944\n",
+      "Election Year: 2016\n",
       "Table 1 Top 2 Candidates + Party: \n",
-      "\t'president_candidate_name': 'Franklin D. Roosevelt', 'president_candidate_party': 'D'\n",
-      "\t'president_candidate_name': 'Thomas E. Dewey', 'president_candidate_party': 'R'\n",
+      "\t'president_candidate_name': 'Donald J. Trump', 'president_candidate_party': 'R'\n",
+      "\t'president_candidate_name': 'Hillary Clinton', 'president_candidate_party': 'D'\n",
       "Table 2 Candidates + Home State: \n",
-      "\t'president_candidate_name': 'Franklin D. Roosevelt', 'col_ind': 1, 'president_candidate_state': 'New York'\n",
-      "\t'president_candidate_name': 'Thomas E. Dewey', 'col_ind': 2, 'president_candidate_state': 'New York'\n",
+      "\t'president_candidate_name': 'Donald Trump', 'col_ind': 1, 'president_candidate_state': 'New York'\n",
+      "\t'president_candidate_name': 'Other', 'col_ind': 2, 'president_candidate_state': None\n",
+      "\t'president_candidate_name': 'Hillary Clinton', 'col_ind': 3, 'president_candidate_state': 'New York'\n",
+      "\t'president_candidate_name': 'Other', 'col_ind': 4, 'president_candidate_state': None\n",
       "Table 2 Votes by State: \n",
-      "\t'state': 'Alabama', 'total_electoral_votes': 11, 1: 11, 2: 0\n",
-      "\t'state': 'Arizona', 'total_electoral_votes': 4, 1: 4, 2: 0\n",
-      "\t'state': 'Arkansas', 'total_electoral_votes': 9, 1: 9, 2: 0\n",
-      "\t'state': 'California', 'total_electoral_votes': 25, 1: 25, 2: 0\n",
-      "\t'state': 'Colorado', 'total_electoral_votes': 6, 1: 0, 2: 6\n",
-      "\t'state': 'Connecticut', 'total_electoral_votes': 8, 1: 8, 2: 0\n",
-      "\t'state': 'Delaware', 'total_electoral_votes': 3, 1: 3, 2: 0\n",
-      "\t'state': 'Florida', 'total_electoral_votes': 8, 1: 8, 2: 0\n",
-      "\t'state': 'Georgia', 'total_electoral_votes': 12, 1: 12, 2: 0\n",
-      "\t'state': 'Idaho', 'total_electoral_votes': 4, 1: 4, 2: 0\n",
-      "\t'state': 'Illinois', 'total_electoral_votes': 28, 1: 28, 2: 0\n",
-      "\t'state': 'Indiana', 'total_electoral_votes': 13, 1: 0, 2: 13\n",
-      "\t'state': 'Iowa', 'total_electoral_votes': 10, 1: 0, 2: 10\n",
-      "\t'state': 'Kansas', 'total_electoral_votes': 8, 1: 0, 2: 8\n",
-      "\t'state': 'Kentucky', 'total_electoral_votes': 11, 1: 11, 2: 0\n",
-      "\t'state': 'Louisiana', 'total_electoral_votes': 10, 1: 10, 2: 0\n",
-      "\t'state': 'Maine', 'total_electoral_votes': 5, 1: 0, 2: 5\n",
-      "\t'state': 'Maryland', 'total_electoral_votes': 8, 1: 8, 2: 0\n",
-      "\t'state': 'Massachusetts', 'total_electoral_votes': 16, 1: 16, 2: 0\n",
-      "\t'state': 'Michigan', 'total_electoral_votes': 19, 1: 19, 2: 0\n",
-      "\t'state': 'Minnesota', 'total_electoral_votes': 11, 1: 11, 2: 0\n",
-      "\t'state': 'Mississippi', 'total_electoral_votes': 9, 1: 9, 2: 0\n",
-      "\t'state': 'Missouri', 'total_electoral_votes': 15, 1: 15, 2: 0\n",
-      "\t'state': 'Montana', 'total_electoral_votes': 4, 1: 4, 2: 0\n",
-      "\t'state': 'Nebraska', 'total_electoral_votes': 6, 1: 0, 2: 6\n",
-      "\t'state': 'Nevada', 'total_electoral_votes': 3, 1: 3, 2: 0\n",
-      "\t'state': 'New Hampshire', 'total_electoral_votes': 4, 1: 4, 2: 0\n",
-      "\t'state': 'New Jersey', 'total_electoral_votes': 16, 1: 16, 2: 0\n",
-      "\t'state': 'New Mexico', 'total_electoral_votes': 4, 1: 4, 2: 0\n",
-      "\t'state': 'New York', 'total_electoral_votes': 47, 1: 47, 2: 0\n",
-      "\t'state': 'North Carolina', 'total_electoral_votes': 14, 1: 14, 2: 0\n",
-      "\t'state': 'North Dakota', 'total_electoral_votes': 4, 1: 0, 2: 4\n",
-      "\t'state': 'Ohio', 'total_electoral_votes': 25, 1: 0, 2: 25\n",
-      "\t'state': 'Oklahoma', 'total_electoral_votes': 10, 1: 10, 2: 0\n",
-      "\t'state': 'Oregon', 'total_electoral_votes': 6, 1: 6, 2: 0\n",
-      "\t'state': 'Pennsylvania', 'total_electoral_votes': 35, 1: 35, 2: 0\n",
-      "\t'state': 'Rhode Island', 'total_electoral_votes': 4, 1: 4, 2: 0\n",
-      "\t'state': 'South Carolina', 'total_electoral_votes': 8, 1: 8, 2: 0\n",
-      "\t'state': 'South Dakota', 'total_electoral_votes': 4, 1: 0, 2: 4\n",
-      "\t'state': 'Tennessee', 'total_electoral_votes': 12, 1: 12, 2: 0\n",
-      "\t'state': 'Texas', 'total_electoral_votes': 23, 1: 23, 2: 0\n",
-      "\t'state': 'Utah', 'total_electoral_votes': 4, 1: 4, 2: 0\n",
-      "\t'state': 'Vermont', 'total_electoral_votes': 3, 1: 0, 2: 3\n",
-      "\t'state': 'Virginia', 'total_electoral_votes': 11, 1: 11, 2: 0\n",
-      "\t'state': 'Washington', 'total_electoral_votes': 8, 1: 8, 2: 0\n",
-      "\t'state': 'West Virginia', 'total_electoral_votes': 8, 1: 8, 2: 0\n",
-      "\t'state': 'Wisconsin', 'total_electoral_votes': 12, 1: 0, 2: 12\n",
-      "\t'state': 'Wyoming', 'total_electoral_votes': 3, 1: 0, 2: 3\n",
-      "\t'state': 'Totals', 'total_electoral_votes': 531, 1: 432, 2: 99\n"
+      "\t'state': 'Alabama', 'total_electoral_votes': 9, 1: 9, 2: 0, 3: 0, 4: 0\n",
+      "\t'state': 'Alaska', 'total_electoral_votes': 3, 1: 3, 2: 0, 3: 0, 4: 0\n",
+      "\t'state': 'Arizona', 'total_electoral_votes': 11, 1: 11, 2: 0, 3: 0, 4: 0\n",
+      "\t'state': 'Arkansas', 'total_electoral_votes': 6, 1: 6, 2: 0, 3: 0, 4: 0\n",
+      "\t'state': 'California', 'total_electoral_votes': 55, 1: 0, 2: 0, 3: 55, 4: 0\n",
+      "\t'state': 'Colorado', 'total_electoral_votes': 9, 1: 0, 2: 0, 3: 9, 4: 0\n",
+      "\t'state': 'Connecticut', 'total_electoral_votes': 7, 1: 0, 2: 0, 3: 7, 4: 0\n",
+      "\t'state': 'Delaware', 'total_electoral_votes': 3, 1: 0, 2: 0, 3: 3, 4: 0\n",
+      "\t'state': 'District of Columbia', 'total_electoral_votes': 3, 1: 0, 2: 0, 3: 3, 4: 0\n",
+      "\t'state': 'Florida', 'total_electoral_votes': 29, 1: 29, 2: 0, 3: 0, 4: 0\n",
+      "\t'state': 'Georgia', 'total_electoral_votes': 16, 1: 16, 2: 0, 3: 0, 4: 0\n",
+      "\t'state': 'Hawaii', 'total_electoral_votes': 4, 1: 0, 2: 0, 3: 3, 4: 1\n",
+      "\t'state': 'Idaho', 'total_electoral_votes': 4, 1: 4, 2: 0, 3: 0, 4: 0\n",
+      "\t'state': 'Illinois', 'total_electoral_votes': 20, 1: 0, 2: 0, 3: 20, 4: 0\n",
+      "\t'state': 'Indiana', 'total_electoral_votes': 11, 1: 11, 2: 0, 3: 0, 4: 0\n",
+      "\t'state': 'Iowa', 'total_electoral_votes': 6, 1: 6, 2: 0, 3: 0, 4: 0\n",
+      "\t'state': 'Kansas', 'total_electoral_votes': 6, 1: 6, 2: 0, 3: 0, 4: 0\n",
+      "\t'state': 'Kentucky', 'total_electoral_votes': 8, 1: 8, 2: 0, 3: 0, 4: 0\n",
+      "\t'state': 'Louisiana', 'total_electoral_votes': 8, 1: 8, 2: 0, 3: 0, 4: 0\n",
+      "\t'state': 'Maine', 'total_electoral_votes': 4, 1: 1, 2: 0, 3: 3, 4: 0\n",
+      "\t'state': 'Maryland', 'total_electoral_votes': 10, 1: 0, 2: 0, 3: 10, 4: 0\n",
+      "\t'state': 'Massachusetts', 'total_electoral_votes': 11, 1: 0, 2: 0, 3: 11, 4: 0\n",
+      "\t'state': 'Michigan', 'total_electoral_votes': 16, 1: 16, 2: 0, 3: 0, 4: 0\n",
+      "\t'state': 'Minnesota', 'total_electoral_votes': 10, 1: 0, 2: 0, 3: 10, 4: 0\n",
+      "\t'state': 'Mississippi', 'total_electoral_votes': 6, 1: 6, 2: 0, 3: 0, 4: 0\n",
+      "\t'state': 'Missouri', 'total_electoral_votes': 10, 1: 10, 2: 0, 3: 0, 4: 0\n",
+      "\t'state': 'Montana', 'total_electoral_votes': 3, 1: 3, 2: 0, 3: 0, 4: 0\n",
+      "\t'state': 'Nebraska', 'total_electoral_votes': 5, 1: 5, 2: 0, 3: 0, 4: 0\n",
+      "\t'state': 'Nevada', 'total_electoral_votes': 6, 1: 0, 2: 0, 3: 6, 4: 0\n",
+      "\t'state': 'New Hampshire', 'total_electoral_votes': 4, 1: 0, 2: 0, 3: 4, 4: 0\n",
+      "\t'state': 'New Jersey', 'total_electoral_votes': 14, 1: 0, 2: 0, 3: 14, 4: 0\n",
+      "\t'state': 'New Mexico', 'total_electoral_votes': 5, 1: 0, 2: 0, 3: 5, 4: 0\n",
+      "\t'state': 'New York', 'total_electoral_votes': 29, 1: 0, 2: 0, 3: 29, 4: 0\n",
+      "\t'state': 'North Carolina', 'total_electoral_votes': 15, 1: 15, 2: 0, 3: 0, 4: 0\n",
+      "\t'state': 'North Dakota', 'total_electoral_votes': 3, 1: 3, 2: 0, 3: 0, 4: 0\n",
+      "\t'state': 'Ohio', 'total_electoral_votes': 18, 1: 18, 2: 0, 3: 0, 4: 0\n",
+      "\t'state': 'Oklahoma', 'total_electoral_votes': 7, 1: 7, 2: 0, 3: 0, 4: 0\n",
+      "\t'state': 'Oregon', 'total_electoral_votes': 7, 1: 0, 2: 0, 3: 7, 4: 0\n",
+      "\t'state': 'Pennsylvania', 'total_electoral_votes': 20, 1: 20, 2: 0, 3: 0, 4: 0\n",
+      "\t'state': 'Rhode Island', 'total_electoral_votes': 4, 1: 0, 2: 0, 3: 4, 4: 0\n",
+      "\t'state': 'South Carolina', 'total_electoral_votes': 9, 1: 9, 2: 0, 3: 0, 4: 0\n",
+      "\t'state': 'South Dakota', 'total_electoral_votes': 3, 1: 3, 2: 0, 3: 0, 4: 0\n",
+      "\t'state': 'Tennessee', 'total_electoral_votes': 11, 1: 11, 2: 0, 3: 0, 4: 0\n",
+      "\t'state': 'Texas', 'total_electoral_votes': 38, 1: 36, 2: 2, 3: 0, 4: 0\n",
+      "\t'state': 'Utah', 'total_electoral_votes': 6, 1: 6, 2: 0, 3: 0, 4: 0\n",
+      "\t'state': 'Vermont', 'total_electoral_votes': 3, 1: 0, 2: 0, 3: 3, 4: 0\n",
+      "\t'state': 'Virginia', 'total_electoral_votes': 13, 1: 0, 2: 0, 3: 13, 4: 0\n",
+      "\t'state': 'Washington', 'total_electoral_votes': 12, 1: 0, 2: 0, 3: 8, 4: 4\n",
+      "\t'state': 'West Virginia', 'total_electoral_votes': 5, 1: 5, 2: 0, 3: 0, 4: 0\n",
+      "\t'state': 'Wisconsin', 'total_electoral_votes': 10, 1: 10, 2: 0, 3: 0, 4: 0\n",
+      "\t'state': 'Wyoming', 'total_electoral_votes': 3, 1: 3, 2: 0, 3: 0, 4: 0\n",
+      "\t'state': 'Totals', 'total_electoral_votes': 538, 1: 304, 2: 2, 3: 227, 4: 5\n"
      ]
     }
    ],
    "source": [
-    "year_index = 13\n",
+    "year_index = 31\n",
     "print_election_year_results(parsed_election_years[year_index])"
    ]
   },
@@ -606,7 +628,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1180,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -615,7 +637,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1181,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -694,7 +716,7 @@
        "4         William J. Bryan        2                  Nebraska  1896"
       ]
      },
-     "execution_count": 1181,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -705,7 +727,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1182,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
@@ -732,7 +754,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1183,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
@@ -787,7 +809,7 @@
        "76                    Other        4                      None  2016"
       ]
      },
-     "execution_count": 1183,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -805,7 +827,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1184,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -814,7 +836,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1185,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
@@ -845,7 +867,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1186,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -862,7 +884,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1187,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -872,7 +894,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1188,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -882,7 +904,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1189,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -893,7 +915,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1190,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [
     {
@@ -1563,7 +1585,7 @@
        "56        None  "
       ]
      },
-     "execution_count": 1190,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1587,7 +1609,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1191,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [
     {
@@ -1646,7 +1668,7 @@
        "38    Richard     Nixon     2"
       ]
      },
-     "execution_count": 1191,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1658,7 +1680,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1192,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [
     {
@@ -1719,7 +1741,7 @@
        "56  Donald J. Trump   Florida     Donald          J.     Trump        None"
       ]
      },
-     "execution_count": 1192,
+     "execution_count": 26,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1737,7 +1759,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1193,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1749,7 +1771,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1194,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [
     {
@@ -1810,7 +1832,7 @@
        "56  Donald J. Trump   Florida     Donald          J.     Trump        None"
       ]
      },
-     "execution_count": 1194,
+     "execution_count": 28,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1830,7 +1852,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1195,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [
     {
@@ -1879,7 +1901,7 @@
        "40  Richard M. Nixon     2"
       ]
      },
-     "execution_count": 1195,
+     "execution_count": 29,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1891,7 +1913,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1196,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [
     {
@@ -1972,7 +1994,7 @@
        "56   Donald J. Trump     Florida     Donald          J.     Trump        None"
       ]
      },
-     "execution_count": 1196,
+     "execution_count": 30,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1983,7 +2005,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1197,
+   "execution_count": 31,
    "metadata": {},
    "outputs": [
     {
@@ -2012,7 +2034,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1198,
+   "execution_count": 32,
    "metadata": {},
    "outputs": [
     {
@@ -2660,7 +2682,7 @@
        "54             Delaware  "
       ]
      },
-     "execution_count": 1198,
+     "execution_count": 32,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2680,7 +2702,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1199,
+   "execution_count": 33,
    "metadata": {
     "tags": []
    },
@@ -3386,7 +3408,7 @@
        "54        Delaware      None  "
       ]
      },
-     "execution_count": 1199,
+     "execution_count": 33,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3407,7 +3429,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1200,
+   "execution_count": 34,
    "metadata": {},
    "outputs": [
     {
@@ -3431,7 +3453,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1201,
+   "execution_count": 35,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3440,7 +3462,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1202,
+   "execution_count": 36,
    "metadata": {},
    "outputs": [
     {
@@ -3476,7 +3498,7 @@
        "Name: state, dtype: int64"
       ]
      },
-     "execution_count": 1202,
+     "execution_count": 36,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3488,7 +3510,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1203,
+   "execution_count": 37,
    "metadata": {},
    "outputs": [
     {
@@ -3500,7 +3522,7 @@
        "Name: state_2, dtype: int64"
       ]
      },
-     "execution_count": 1203,
+     "execution_count": 37,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3519,7 +3541,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1204,
+   "execution_count": 38,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3528,7 +3550,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1205,
+   "execution_count": 39,
    "metadata": {},
    "outputs": [
     {
@@ -3554,7 +3576,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1206,
+   "execution_count": 40,
    "metadata": {},
    "outputs": [
     {
@@ -3627,7 +3649,7 @@
        "4         William McKinley                         R  1900"
       ]
      },
-     "execution_count": 1206,
+     "execution_count": 40,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3638,7 +3660,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1207,
+   "execution_count": 41,
    "metadata": {},
    "outputs": [
     {
@@ -3651,7 +3673,7 @@
        "Name: president_candidate_party, dtype: int64"
       ]
      },
-     "execution_count": 1207,
+     "execution_count": 41,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3662,7 +3684,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1208,
+   "execution_count": 42,
    "metadata": {},
    "outputs": [
     {
@@ -3686,7 +3708,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1209,
+   "execution_count": 43,
    "metadata": {},
    "outputs": [
     {
@@ -3745,7 +3767,7 @@
        "9         William J. Bryan                         D  1908"
       ]
      },
-     "execution_count": 1209,
+     "execution_count": 43,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3757,7 +3779,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1210,
+   "execution_count": 44,
    "metadata": {},
    "outputs": [
     {
@@ -3809,7 +3831,7 @@
        "5         William J. Bryan                       D-P  1900"
       ]
      },
-     "execution_count": 1210,
+     "execution_count": 44,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3821,7 +3843,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1211,
+   "execution_count": 45,
    "metadata": {},
    "outputs": [
     {
@@ -3873,7 +3895,7 @@
        "11       Theodore Roosevelt                         P  1912"
       ]
      },
-     "execution_count": 1211,
+     "execution_count": 45,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3893,7 +3915,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1212,
+   "execution_count": 46,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -3909,7 +3931,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1213,
+   "execution_count": 47,
    "metadata": {},
    "outputs": [
     {
@@ -3976,7 +3998,7 @@
        "4  Theodore Roosevelt     R"
       ]
      },
-     "execution_count": 1213,
+     "execution_count": 47,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3997,7 +4019,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1214,
+   "execution_count": 48,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4013,7 +4035,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1215,
+   "execution_count": 49,
    "metadata": {},
    "outputs": [
     {
@@ -4366,7 +4388,7 @@
        "44         Woodrow Wilson     D    None"
       ]
      },
-     "execution_count": 1215,
+     "execution_count": 49,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4387,7 +4409,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1216,
+   "execution_count": 50,
    "metadata": {},
    "outputs": [
     {
@@ -4411,7 +4433,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1217,
+   "execution_count": 51,
    "metadata": {},
    "outputs": [
     {
@@ -4422,7 +4444,7 @@
        "Name: party, dtype: int64"
       ]
      },
-     "execution_count": 1217,
+     "execution_count": 51,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4434,7 +4456,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1218,
+   "execution_count": 52,
    "metadata": {},
    "outputs": [
     {
@@ -4444,7 +4466,7 @@
        "Name: party_2, dtype: int64"
       ]
      },
-     "execution_count": 1218,
+     "execution_count": 52,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4467,14 +4489,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1219,
+   "execution_count": 53,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'Bob Dole', 'George S. McGovern'}\n"
+      "{'George S. McGovern', 'Bob Dole'}\n"
      ]
     }
    ],
@@ -4486,7 +4508,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1220,
+   "execution_count": 54,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4495,7 +4517,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1221,
+   "execution_count": 55,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4505,7 +4527,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1222,
+   "execution_count": 56,
    "metadata": {},
    "outputs": [
     {
@@ -4540,7 +4562,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1223,
+   "execution_count": 57,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4549,7 +4571,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1224,
+   "execution_count": 58,
    "metadata": {},
    "outputs": [
     {
@@ -4588,7 +4610,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1225,
+   "execution_count": 59,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4606,7 +4628,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1226,
+   "execution_count": 60,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -4623,7 +4645,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1517,
+   "execution_count": 61,
    "metadata": {},
    "outputs": [
     {
@@ -4656,7 +4678,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1227,
+   "execution_count": 62,
    "metadata": {},
    "outputs": [
     {
@@ -5528,7 +5550,7 @@
        "54         Jr.        Delaware      None     D    None  "
       ]
      },
-     "execution_count": 1227,
+     "execution_count": 62,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -5539,7 +5561,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1228,
+   "execution_count": 63,
    "metadata": {},
    "outputs": [
     {
@@ -5556,7 +5578,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1229,
+   "execution_count": 64,
    "metadata": {},
    "outputs": [
     {
@@ -5574,7 +5596,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1230,
+   "execution_count": 65,
    "metadata": {},
    "outputs": [
     {
@@ -5592,7 +5614,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1231,
+   "execution_count": 66,
    "metadata": {},
    "outputs": [
     {
@@ -5610,7 +5632,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1232,
+   "execution_count": 67,
    "metadata": {},
    "outputs": [
     {
@@ -5628,7 +5650,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1233,
+   "execution_count": 68,
    "metadata": {},
    "outputs": [
     {
@@ -5675,7 +5697,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1552,
+   "execution_count": 178,
    "metadata": {},
    "outputs": [
     {
@@ -5700,7 +5722,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1553,
+   "execution_count": 179,
    "metadata": {},
    "outputs": [
     {
@@ -5719,7 +5741,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1554,
+   "execution_count": 180,
    "metadata": {},
    "outputs": [
     {
@@ -5780,7 +5802,7 @@
        "4  California"
       ]
      },
-     "execution_count": 1554,
+     "execution_count": 180,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -5803,7 +5825,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1555,
+   "execution_count": 181,
    "metadata": {},
    "outputs": [
     {
@@ -5841,7 +5863,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1556,
+   "execution_count": 182,
    "metadata": {},
    "outputs": [
     {
@@ -6000,7 +6022,7 @@
        "4  POLYGON ((-77.45881 39.22027, -77.45866 39.220...  "
       ]
      },
-     "execution_count": 1556,
+     "execution_count": 182,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -6011,7 +6033,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1557,
+   "execution_count": 183,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -6021,7 +6043,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1558,
+   "execution_count": 184,
    "metadata": {},
    "outputs": [
     {
@@ -6062,7 +6084,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1559,
+   "execution_count": 185,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -6071,7 +6093,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1560,
+   "execution_count": 186,
    "metadata": {},
    "outputs": [
     {
@@ -6112,7 +6134,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1561,
+   "execution_count": 187,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -6132,7 +6154,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1562,
+   "execution_count": 188,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -6140,16 +6162,8 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "#### **3.3.3 Validate Final State Table**\n",
-    "Make sure that no state data has been lost along the way."
-   ]
-  },
-  {
    "cell_type": "code",
-   "execution_count": 1563,
+   "execution_count": 190,
    "metadata": {},
    "outputs": [
     {
@@ -6162,11 +6176,53 @@
       " #   Column      Non-Null Count  Dtype  \n",
       "---  ------      --------------  -----  \n",
       " 0   state       51 non-null     object \n",
-      " 1   region      51 non-null     int64  \n",
-      " 2   division    51 non-null     int64  \n",
-      " 3   statens     51 non-null     object \n",
-      " 4   geoid       51 non-null     object \n",
-      " 5   state_usps  51 non-null     object \n",
+      " 1   state_usps  51 non-null     object \n",
+      " 2   region      51 non-null     int64  \n",
+      " 3   division    51 non-null     int64  \n",
+      " 4   statens     51 non-null     object \n",
+      " 5   geoid       51 non-null     object \n",
+      " 6   area_land   51 non-null     int64  \n",
+      " 7   area_water  51 non-null     int64  \n",
+      " 8   latitude    51 non-null     float64\n",
+      " 9   longitude   51 non-null     float64\n",
+      "dtypes: float64(2), int64(4), object(4)\n",
+      "memory usage: 4.4+ KB\n"
+     ]
+    }
+   ],
+   "source": [
+    "state_df = state_df.iloc[:, [0, 5, 1, 2, 3, 4, 6, 7, 8, 9]]\n",
+    "state_df.info()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### **3.3.3 Validate Final State Table**\n",
+    "Make sure that no state data has been lost along the way."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 191,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<class 'pandas.core.frame.DataFrame'>\n",
+      "Int64Index: 51 entries, 0 to 50\n",
+      "Data columns (total 10 columns):\n",
+      " #   Column      Non-Null Count  Dtype  \n",
+      "---  ------      --------------  -----  \n",
+      " 0   state       51 non-null     object \n",
+      " 1   state_usps  51 non-null     object \n",
+      " 2   region      51 non-null     int64  \n",
+      " 3   division    51 non-null     int64  \n",
+      " 4   statens     51 non-null     object \n",
+      " 5   geoid       51 non-null     object \n",
       " 6   area_land   51 non-null     int64  \n",
       " 7   area_water  51 non-null     int64  \n",
       " 8   latitude    51 non-null     float64\n",
@@ -6182,7 +6238,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1564,
+   "execution_count": 192,
    "metadata": {},
    "outputs": [
     {
@@ -6207,11 +6263,11 @@
        "    <tr style=\"text-align: right;\">\n",
        "      <th></th>\n",
        "      <th>state</th>\n",
+       "      <th>state_usps</th>\n",
        "      <th>region</th>\n",
        "      <th>division</th>\n",
        "      <th>statens</th>\n",
        "      <th>geoid</th>\n",
-       "      <th>state_usps</th>\n",
        "      <th>area_land</th>\n",
        "      <th>area_water</th>\n",
        "      <th>latitude</th>\n",
@@ -6222,11 +6278,11 @@
        "    <tr>\n",
        "      <th>0</th>\n",
        "      <td>Alabama</td>\n",
+       "      <td>AL</td>\n",
        "      <td>3</td>\n",
        "      <td>6</td>\n",
        "      <td>01779775</td>\n",
        "      <td>01</td>\n",
-       "      <td>AL</td>\n",
        "      <td>131174192284</td>\n",
        "      <td>4593183334</td>\n",
        "      <td>32.739632</td>\n",
@@ -6235,11 +6291,11 @@
        "    <tr>\n",
        "      <th>1</th>\n",
        "      <td>Alaska</td>\n",
+       "      <td>AK</td>\n",
        "      <td>4</td>\n",
        "      <td>9</td>\n",
        "      <td>01785533</td>\n",
        "      <td>02</td>\n",
-       "      <td>AK</td>\n",
        "      <td>1478927050067</td>\n",
        "      <td>245394222619</td>\n",
        "      <td>63.347356</td>\n",
@@ -6248,11 +6304,11 @@
        "    <tr>\n",
        "      <th>2</th>\n",
        "      <td>Arizona</td>\n",
+       "      <td>AZ</td>\n",
        "      <td>4</td>\n",
        "      <td>8</td>\n",
        "      <td>01779777</td>\n",
        "      <td>04</td>\n",
-       "      <td>AZ</td>\n",
        "      <td>294360282618</td>\n",
        "      <td>859561204</td>\n",
        "      <td>34.203936</td>\n",
@@ -6261,11 +6317,11 @@
        "    <tr>\n",
        "      <th>3</th>\n",
        "      <td>Arkansas</td>\n",
+       "      <td>AR</td>\n",
        "      <td>3</td>\n",
        "      <td>7</td>\n",
        "      <td>00068085</td>\n",
        "      <td>05</td>\n",
-       "      <td>AR</td>\n",
        "      <td>134776580080</td>\n",
        "      <td>2956395922</td>\n",
        "      <td>34.895526</td>\n",
@@ -6274,11 +6330,11 @@
        "    <tr>\n",
        "      <th>4</th>\n",
        "      <td>California</td>\n",
+       "      <td>CA</td>\n",
        "      <td>4</td>\n",
        "      <td>9</td>\n",
        "      <td>01779778</td>\n",
        "      <td>06</td>\n",
-       "      <td>CA</td>\n",
        "      <td>403660088482</td>\n",
        "      <td>20305454540</td>\n",
        "      <td>37.155177</td>\n",
@@ -6287,11 +6343,11 @@
        "    <tr>\n",
        "      <th>5</th>\n",
        "      <td>Colorado</td>\n",
+       "      <td>CO</td>\n",
        "      <td>4</td>\n",
        "      <td>8</td>\n",
        "      <td>01779779</td>\n",
        "      <td>08</td>\n",
-       "      <td>CO</td>\n",
        "      <td>268419875371</td>\n",
        "      <td>1184637800</td>\n",
        "      <td>38.993848</td>\n",
@@ -6300,11 +6356,11 @@
        "    <tr>\n",
        "      <th>6</th>\n",
        "      <td>Connecticut</td>\n",
+       "      <td>CT</td>\n",
        "      <td>1</td>\n",
        "      <td>1</td>\n",
        "      <td>01779780</td>\n",
        "      <td>09</td>\n",
-       "      <td>CT</td>\n",
        "      <td>12542497381</td>\n",
        "      <td>1815617293</td>\n",
        "      <td>41.579864</td>\n",
@@ -6313,11 +6369,11 @@
        "    <tr>\n",
        "      <th>7</th>\n",
        "      <td>Delaware</td>\n",
+       "      <td>DE</td>\n",
        "      <td>3</td>\n",
        "      <td>5</td>\n",
        "      <td>01779781</td>\n",
        "      <td>10</td>\n",
-       "      <td>DE</td>\n",
        "      <td>5046620081</td>\n",
        "      <td>1399291164</td>\n",
        "      <td>38.998566</td>\n",
@@ -6326,11 +6382,11 @@
        "    <tr>\n",
        "      <th>8</th>\n",
        "      <td>District of Columbia</td>\n",
+       "      <td>DC</td>\n",
        "      <td>3</td>\n",
        "      <td>5</td>\n",
        "      <td>01702382</td>\n",
        "      <td>11</td>\n",
-       "      <td>DC</td>\n",
        "      <td>158340389</td>\n",
        "      <td>18687196</td>\n",
        "      <td>38.904247</td>\n",
@@ -6339,11 +6395,11 @@
        "    <tr>\n",
        "      <th>9</th>\n",
        "      <td>Florida</td>\n",
+       "      <td>FL</td>\n",
        "      <td>3</td>\n",
        "      <td>5</td>\n",
        "      <td>00294478</td>\n",
        "      <td>12</td>\n",
-       "      <td>FL</td>\n",
        "      <td>138947364717</td>\n",
        "      <td>31362872853</td>\n",
        "      <td>28.457430</td>\n",
@@ -6352,11 +6408,11 @@
        "    <tr>\n",
        "      <th>10</th>\n",
        "      <td>Georgia</td>\n",
+       "      <td>GA</td>\n",
        "      <td>3</td>\n",
        "      <td>5</td>\n",
        "      <td>01705317</td>\n",
        "      <td>13</td>\n",
-       "      <td>GA</td>\n",
        "      <td>149484604230</td>\n",
        "      <td>4420380296</td>\n",
        "      <td>32.629579</td>\n",
@@ -6365,11 +6421,11 @@
        "    <tr>\n",
        "      <th>11</th>\n",
        "      <td>Hawaii</td>\n",
+       "      <td>HI</td>\n",
        "      <td>4</td>\n",
        "      <td>9</td>\n",
        "      <td>01779782</td>\n",
        "      <td>15</td>\n",
-       "      <td>HI</td>\n",
        "      <td>16634006436</td>\n",
        "      <td>11777792811</td>\n",
        "      <td>19.597764</td>\n",
@@ -6378,11 +6434,11 @@
        "    <tr>\n",
        "      <th>12</th>\n",
        "      <td>Idaho</td>\n",
+       "      <td>ID</td>\n",
        "      <td>4</td>\n",
        "      <td>8</td>\n",
        "      <td>01779783</td>\n",
        "      <td>16</td>\n",
-       "      <td>ID</td>\n",
        "      <td>214049897859</td>\n",
        "      <td>2391604238</td>\n",
        "      <td>44.348422</td>\n",
@@ -6391,11 +6447,11 @@
        "    <tr>\n",
        "      <th>13</th>\n",
        "      <td>Illinois</td>\n",
+       "      <td>IL</td>\n",
        "      <td>2</td>\n",
        "      <td>3</td>\n",
        "      <td>01779784</td>\n",
        "      <td>17</td>\n",
-       "      <td>IL</td>\n",
        "      <td>143779863817</td>\n",
        "      <td>6215723896</td>\n",
        "      <td>40.102875</td>\n",
@@ -6404,11 +6460,11 @@
        "    <tr>\n",
        "      <th>14</th>\n",
        "      <td>Indiana</td>\n",
+       "      <td>IN</td>\n",
        "      <td>2</td>\n",
        "      <td>3</td>\n",
        "      <td>00448508</td>\n",
        "      <td>18</td>\n",
-       "      <td>IN</td>\n",
        "      <td>92790048198</td>\n",
        "      <td>1537252652</td>\n",
        "      <td>39.901314</td>\n",
@@ -6417,11 +6473,11 @@
        "    <tr>\n",
        "      <th>15</th>\n",
        "      <td>Iowa</td>\n",
+       "      <td>IA</td>\n",
        "      <td>2</td>\n",
        "      <td>4</td>\n",
        "      <td>01779785</td>\n",
        "      <td>19</td>\n",
-       "      <td>IA</td>\n",
        "      <td>144660467237</td>\n",
        "      <td>1084981626</td>\n",
        "      <td>42.070024</td>\n",
@@ -6430,11 +6486,11 @@
        "    <tr>\n",
        "      <th>16</th>\n",
        "      <td>Kansas</td>\n",
+       "      <td>KS</td>\n",
        "      <td>2</td>\n",
        "      <td>4</td>\n",
        "      <td>00481813</td>\n",
        "      <td>20</td>\n",
-       "      <td>KS</td>\n",
        "      <td>211753474780</td>\n",
        "      <td>1346010601</td>\n",
        "      <td>38.498546</td>\n",
@@ -6443,11 +6499,11 @@
        "    <tr>\n",
        "      <th>17</th>\n",
        "      <td>Kentucky</td>\n",
+       "      <td>KY</td>\n",
        "      <td>3</td>\n",
        "      <td>6</td>\n",
        "      <td>01779786</td>\n",
        "      <td>21</td>\n",
-       "      <td>KY</td>\n",
        "      <td>102282218059</td>\n",
        "      <td>2372611005</td>\n",
        "      <td>37.533684</td>\n",
@@ -6456,11 +6512,11 @@
        "    <tr>\n",
        "      <th>18</th>\n",
        "      <td>Louisiana</td>\n",
+       "      <td>LA</td>\n",
        "      <td>3</td>\n",
        "      <td>7</td>\n",
        "      <td>01629543</td>\n",
        "      <td>22</td>\n",
-       "      <td>LA</td>\n",
        "      <td>111899106382</td>\n",
        "      <td>23752001883</td>\n",
        "      <td>30.863437</td>\n",
@@ -6469,11 +6525,11 @@
        "    <tr>\n",
        "      <th>19</th>\n",
        "      <td>Maine</td>\n",
+       "      <td>ME</td>\n",
        "      <td>1</td>\n",
        "      <td>1</td>\n",
        "      <td>01779787</td>\n",
        "      <td>23</td>\n",
-       "      <td>ME</td>\n",
        "      <td>79887659040</td>\n",
        "      <td>11745717739</td>\n",
        "      <td>45.409284</td>\n",
@@ -6482,11 +6538,11 @@
        "    <tr>\n",
        "      <th>20</th>\n",
        "      <td>Maryland</td>\n",
+       "      <td>MD</td>\n",
        "      <td>3</td>\n",
        "      <td>5</td>\n",
        "      <td>01714934</td>\n",
        "      <td>24</td>\n",
-       "      <td>MD</td>\n",
        "      <td>25151726296</td>\n",
        "      <td>6979340970</td>\n",
        "      <td>38.946658</td>\n",
@@ -6495,11 +6551,11 @@
        "    <tr>\n",
        "      <th>21</th>\n",
        "      <td>Massachusetts</td>\n",
+       "      <td>MA</td>\n",
        "      <td>1</td>\n",
        "      <td>1</td>\n",
        "      <td>00606926</td>\n",
        "      <td>25</td>\n",
-       "      <td>MA</td>\n",
        "      <td>20204387828</td>\n",
        "      <td>7130663019</td>\n",
        "      <td>42.156520</td>\n",
@@ -6508,11 +6564,11 @@
        "    <tr>\n",
        "      <th>22</th>\n",
        "      <td>Michigan</td>\n",
+       "      <td>MI</td>\n",
        "      <td>2</td>\n",
        "      <td>3</td>\n",
        "      <td>01779789</td>\n",
        "      <td>26</td>\n",
-       "      <td>MI</td>\n",
        "      <td>146608689865</td>\n",
        "      <td>103878116983</td>\n",
        "      <td>44.844177</td>\n",
@@ -6521,11 +6577,11 @@
        "    <tr>\n",
        "      <th>23</th>\n",
        "      <td>Minnesota</td>\n",
+       "      <td>MN</td>\n",
        "      <td>2</td>\n",
        "      <td>4</td>\n",
        "      <td>00662849</td>\n",
        "      <td>27</td>\n",
-       "      <td>MN</td>\n",
        "      <td>206230065476</td>\n",
        "      <td>18942261495</td>\n",
        "      <td>46.315957</td>\n",
@@ -6534,11 +6590,11 @@
        "    <tr>\n",
        "      <th>24</th>\n",
        "      <td>Mississippi</td>\n",
+       "      <td>MS</td>\n",
        "      <td>3</td>\n",
        "      <td>6</td>\n",
        "      <td>01779790</td>\n",
        "      <td>28</td>\n",
-       "      <td>MS</td>\n",
        "      <td>121536584987</td>\n",
        "      <td>3923863925</td>\n",
        "      <td>32.686471</td>\n",
@@ -6547,11 +6603,11 @@
        "    <tr>\n",
        "      <th>25</th>\n",
        "      <td>Missouri</td>\n",
+       "      <td>MO</td>\n",
        "      <td>2</td>\n",
        "      <td>4</td>\n",
        "      <td>01779791</td>\n",
        "      <td>29</td>\n",
-       "      <td>MO</td>\n",
        "      <td>178049911275</td>\n",
        "      <td>2489250399</td>\n",
        "      <td>38.350750</td>\n",
@@ -6560,11 +6616,11 @@
        "    <tr>\n",
        "      <th>26</th>\n",
        "      <td>Montana</td>\n",
+       "      <td>MT</td>\n",
        "      <td>4</td>\n",
        "      <td>8</td>\n",
        "      <td>00767982</td>\n",
        "      <td>30</td>\n",
-       "      <td>MT</td>\n",
        "      <td>376966832749</td>\n",
        "      <td>3869031338</td>\n",
        "      <td>47.051177</td>\n",
@@ -6573,11 +6629,11 @@
        "    <tr>\n",
        "      <th>27</th>\n",
        "      <td>Nebraska</td>\n",
+       "      <td>NE</td>\n",
        "      <td>2</td>\n",
        "      <td>4</td>\n",
        "      <td>01779792</td>\n",
        "      <td>31</td>\n",
-       "      <td>NE</td>\n",
        "      <td>198953801353</td>\n",
        "      <td>1374686302</td>\n",
        "      <td>41.543305</td>\n",
@@ -6586,11 +6642,11 @@
        "    <tr>\n",
        "      <th>28</th>\n",
        "      <td>Nevada</td>\n",
+       "      <td>NV</td>\n",
        "      <td>4</td>\n",
        "      <td>8</td>\n",
        "      <td>01779793</td>\n",
        "      <td>32</td>\n",
-       "      <td>NV</td>\n",
        "      <td>284537049864</td>\n",
        "      <td>1839662829</td>\n",
        "      <td>39.331093</td>\n",
@@ -6599,11 +6655,11 @@
        "    <tr>\n",
        "      <th>29</th>\n",
        "      <td>New Hampshire</td>\n",
+       "      <td>NH</td>\n",
        "      <td>1</td>\n",
        "      <td>1</td>\n",
        "      <td>01779794</td>\n",
        "      <td>33</td>\n",
-       "      <td>NH</td>\n",
        "      <td>23189198255</td>\n",
        "      <td>1026903434</td>\n",
        "      <td>43.672691</td>\n",
@@ -6612,11 +6668,11 @@
        "    <tr>\n",
        "      <th>30</th>\n",
        "      <td>New Jersey</td>\n",
+       "      <td>NJ</td>\n",
        "      <td>1</td>\n",
        "      <td>2</td>\n",
        "      <td>01779795</td>\n",
        "      <td>34</td>\n",
-       "      <td>NJ</td>\n",
        "      <td>19048848841</td>\n",
        "      <td>3543837357</td>\n",
        "      <td>40.107274</td>\n",
@@ -6625,11 +6681,11 @@
        "    <tr>\n",
        "      <th>31</th>\n",
        "      <td>New Mexico</td>\n",
+       "      <td>NM</td>\n",
        "      <td>4</td>\n",
        "      <td>8</td>\n",
        "      <td>00897535</td>\n",
        "      <td>35</td>\n",
-       "      <td>NM</td>\n",
        "      <td>314197253999</td>\n",
        "      <td>727781442</td>\n",
        "      <td>34.434684</td>\n",
@@ -6638,11 +6694,11 @@
        "    <tr>\n",
        "      <th>32</th>\n",
        "      <td>New York</td>\n",
+       "      <td>NY</td>\n",
        "      <td>1</td>\n",
        "      <td>2</td>\n",
        "      <td>01779796</td>\n",
        "      <td>36</td>\n",
-       "      <td>NY</td>\n",
        "      <td>122050000805</td>\n",
        "      <td>19246143659</td>\n",
        "      <td>42.913397</td>\n",
@@ -6651,11 +6707,11 @@
        "    <tr>\n",
        "      <th>33</th>\n",
        "      <td>North Carolina</td>\n",
+       "      <td>NC</td>\n",
        "      <td>3</td>\n",
        "      <td>5</td>\n",
        "      <td>01027616</td>\n",
        "      <td>37</td>\n",
-       "      <td>NC</td>\n",
        "      <td>125925929633</td>\n",
        "      <td>13463401534</td>\n",
        "      <td>35.539710</td>\n",
@@ -6664,11 +6720,11 @@
        "    <tr>\n",
        "      <th>34</th>\n",
        "      <td>North Dakota</td>\n",
+       "      <td>ND</td>\n",
        "      <td>2</td>\n",
        "      <td>4</td>\n",
        "      <td>01779797</td>\n",
        "      <td>38</td>\n",
-       "      <td>ND</td>\n",
        "      <td>178695635183</td>\n",
        "      <td>4411365971</td>\n",
        "      <td>47.442174</td>\n",
@@ -6677,11 +6733,11 @@
        "    <tr>\n",
        "      <th>35</th>\n",
        "      <td>Ohio</td>\n",
+       "      <td>OH</td>\n",
        "      <td>2</td>\n",
        "      <td>3</td>\n",
        "      <td>01085497</td>\n",
        "      <td>39</td>\n",
-       "      <td>OH</td>\n",
        "      <td>105823701267</td>\n",
        "      <td>10274036690</td>\n",
        "      <td>40.414930</td>\n",
@@ -6690,11 +6746,11 @@
        "    <tr>\n",
        "      <th>36</th>\n",
        "      <td>Oklahoma</td>\n",
+       "      <td>OK</td>\n",
        "      <td>3</td>\n",
        "      <td>7</td>\n",
        "      <td>01102857</td>\n",
        "      <td>40</td>\n",
-       "      <td>OK</td>\n",
        "      <td>177662675149</td>\n",
        "      <td>3374950118</td>\n",
        "      <td>35.590051</td>\n",
@@ -6703,11 +6759,11 @@
        "    <tr>\n",
        "      <th>37</th>\n",
        "      <td>Oregon</td>\n",
+       "      <td>OR</td>\n",
        "      <td>4</td>\n",
        "      <td>9</td>\n",
        "      <td>01155107</td>\n",
        "      <td>41</td>\n",
-       "      <td>OR</td>\n",
        "      <td>248607777514</td>\n",
        "      <td>6191602576</td>\n",
        "      <td>43.971713</td>\n",
@@ -6716,11 +6772,11 @@
        "    <tr>\n",
        "      <th>38</th>\n",
        "      <td>Pennsylvania</td>\n",
+       "      <td>PA</td>\n",
        "      <td>1</td>\n",
        "      <td>2</td>\n",
        "      <td>01779798</td>\n",
        "      <td>42</td>\n",
-       "      <td>PA</td>\n",
        "      <td>115880457407</td>\n",
        "      <td>3398574954</td>\n",
        "      <td>40.904601</td>\n",
@@ -6729,11 +6785,11 @@
        "    <tr>\n",
        "      <th>39</th>\n",
        "      <td>Rhode Island</td>\n",
+       "      <td>RI</td>\n",
        "      <td>1</td>\n",
        "      <td>1</td>\n",
        "      <td>01219835</td>\n",
        "      <td>44</td>\n",
-       "      <td>RI</td>\n",
        "      <td>2677787140</td>\n",
        "      <td>1323663210</td>\n",
        "      <td>41.597419</td>\n",
@@ -6742,11 +6798,11 @@
        "    <tr>\n",
        "      <th>40</th>\n",
        "      <td>South Carolina</td>\n",
+       "      <td>SC</td>\n",
        "      <td>3</td>\n",
        "      <td>5</td>\n",
        "      <td>01779799</td>\n",
        "      <td>45</td>\n",
-       "      <td>SC</td>\n",
        "      <td>77864659170</td>\n",
        "      <td>5075874513</td>\n",
        "      <td>33.874178</td>\n",
@@ -6755,11 +6811,11 @@
        "    <tr>\n",
        "      <th>41</th>\n",
        "      <td>South Dakota</td>\n",
+       "      <td>SD</td>\n",
        "      <td>2</td>\n",
        "      <td>4</td>\n",
        "      <td>01785534</td>\n",
        "      <td>46</td>\n",
-       "      <td>SD</td>\n",
        "      <td>196346195316</td>\n",
        "      <td>3383460688</td>\n",
        "      <td>44.446796</td>\n",
@@ -6768,11 +6824,11 @@
        "    <tr>\n",
        "      <th>42</th>\n",
        "      <td>Tennessee</td>\n",
+       "      <td>TN</td>\n",
        "      <td>3</td>\n",
        "      <td>6</td>\n",
        "      <td>01325873</td>\n",
        "      <td>47</td>\n",
-       "      <td>TN</td>\n",
        "      <td>106805839178</td>\n",
        "      <td>2347012319</td>\n",
        "      <td>35.860803</td>\n",
@@ -6781,11 +6837,11 @@
        "    <tr>\n",
        "      <th>43</th>\n",
        "      <td>Texas</td>\n",
+       "      <td>TX</td>\n",
        "      <td>3</td>\n",
        "      <td>7</td>\n",
        "      <td>01779801</td>\n",
        "      <td>48</td>\n",
-       "      <td>TX</td>\n",
        "      <td>676668210823</td>\n",
        "      <td>18991880422</td>\n",
        "      <td>31.434703</td>\n",
@@ -6794,11 +6850,11 @@
        "    <tr>\n",
        "      <th>44</th>\n",
        "      <td>Utah</td>\n",
+       "      <td>UT</td>\n",
        "      <td>4</td>\n",
        "      <td>8</td>\n",
        "      <td>01455989</td>\n",
        "      <td>49</td>\n",
-       "      <td>UT</td>\n",
        "      <td>213355135666</td>\n",
        "      <td>6529910339</td>\n",
        "      <td>39.334992</td>\n",
@@ -6807,11 +6863,11 @@
        "    <tr>\n",
        "      <th>45</th>\n",
        "      <td>Vermont</td>\n",
+       "      <td>VT</td>\n",
        "      <td>1</td>\n",
        "      <td>1</td>\n",
        "      <td>01779802</td>\n",
        "      <td>50</td>\n",
-       "      <td>VT</td>\n",
        "      <td>23874197924</td>\n",
        "      <td>1030383955</td>\n",
        "      <td>44.068577</td>\n",
@@ -6820,11 +6876,11 @@
        "    <tr>\n",
        "      <th>46</th>\n",
        "      <td>Virginia</td>\n",
+       "      <td>VA</td>\n",
        "      <td>3</td>\n",
        "      <td>5</td>\n",
        "      <td>01779803</td>\n",
        "      <td>51</td>\n",
-       "      <td>VA</td>\n",
        "      <td>102258306285</td>\n",
        "      <td>8527942672</td>\n",
        "      <td>37.522251</td>\n",
@@ -6833,11 +6889,11 @@
        "    <tr>\n",
        "      <th>47</th>\n",
        "      <td>Washington</td>\n",
+       "      <td>WA</td>\n",
        "      <td>4</td>\n",
        "      <td>9</td>\n",
        "      <td>01779804</td>\n",
        "      <td>53</td>\n",
-       "      <td>WA</td>\n",
        "      <td>172117954267</td>\n",
        "      <td>12549727444</td>\n",
        "      <td>47.407324</td>\n",
@@ -6846,11 +6902,11 @@
        "    <tr>\n",
        "      <th>48</th>\n",
        "      <td>West Virginia</td>\n",
+       "      <td>WV</td>\n",
        "      <td>3</td>\n",
        "      <td>5</td>\n",
        "      <td>01779805</td>\n",
        "      <td>54</td>\n",
-       "      <td>WV</td>\n",
        "      <td>62266231560</td>\n",
        "      <td>489271086</td>\n",
        "      <td>38.647285</td>\n",
@@ -6859,11 +6915,11 @@
        "    <tr>\n",
        "      <th>49</th>\n",
        "      <td>Wisconsin</td>\n",
+       "      <td>WI</td>\n",
        "      <td>2</td>\n",
        "      <td>3</td>\n",
        "      <td>01779806</td>\n",
        "      <td>55</td>\n",
-       "      <td>WI</td>\n",
        "      <td>140293020078</td>\n",
        "      <td>29344176961</td>\n",
        "      <td>44.630907</td>\n",
@@ -6872,11 +6928,11 @@
        "    <tr>\n",
        "      <th>50</th>\n",
        "      <td>Wyoming</td>\n",
+       "      <td>WY</td>\n",
        "      <td>4</td>\n",
        "      <td>8</td>\n",
        "      <td>01779807</td>\n",
        "      <td>56</td>\n",
-       "      <td>WY</td>\n",
        "      <td>251458578211</td>\n",
        "      <td>1867637632</td>\n",
        "      <td>42.989659</td>\n",
@@ -6887,58 +6943,58 @@
        "</div>"
       ],
       "text/plain": [
-       "                   state  region  division   statens geoid state_usps  \\\n",
-       "0                Alabama       3         6  01779775    01         AL   \n",
-       "1                 Alaska       4         9  01785533    02         AK   \n",
-       "2                Arizona       4         8  01779777    04         AZ   \n",
-       "3               Arkansas       3         7  00068085    05         AR   \n",
-       "4             California       4         9  01779778    06         CA   \n",
-       "5               Colorado       4         8  01779779    08         CO   \n",
-       "6            Connecticut       1         1  01779780    09         CT   \n",
-       "7               Delaware       3         5  01779781    10         DE   \n",
-       "8   District of Columbia       3         5  01702382    11         DC   \n",
-       "9                Florida       3         5  00294478    12         FL   \n",
-       "10               Georgia       3         5  01705317    13         GA   \n",
-       "11                Hawaii       4         9  01779782    15         HI   \n",
-       "12                 Idaho       4         8  01779783    16         ID   \n",
-       "13              Illinois       2         3  01779784    17         IL   \n",
-       "14               Indiana       2         3  00448508    18         IN   \n",
-       "15                  Iowa       2         4  01779785    19         IA   \n",
-       "16                Kansas       2         4  00481813    20         KS   \n",
-       "17              Kentucky       3         6  01779786    21         KY   \n",
-       "18             Louisiana       3         7  01629543    22         LA   \n",
-       "19                 Maine       1         1  01779787    23         ME   \n",
-       "20              Maryland       3         5  01714934    24         MD   \n",
-       "21         Massachusetts       1         1  00606926    25         MA   \n",
-       "22              Michigan       2         3  01779789    26         MI   \n",
-       "23             Minnesota       2         4  00662849    27         MN   \n",
-       "24           Mississippi       3         6  01779790    28         MS   \n",
-       "25              Missouri       2         4  01779791    29         MO   \n",
-       "26               Montana       4         8  00767982    30         MT   \n",
-       "27              Nebraska       2         4  01779792    31         NE   \n",
-       "28                Nevada       4         8  01779793    32         NV   \n",
-       "29         New Hampshire       1         1  01779794    33         NH   \n",
-       "30            New Jersey       1         2  01779795    34         NJ   \n",
-       "31            New Mexico       4         8  00897535    35         NM   \n",
-       "32              New York       1         2  01779796    36         NY   \n",
-       "33        North Carolina       3         5  01027616    37         NC   \n",
-       "34          North Dakota       2         4  01779797    38         ND   \n",
-       "35                  Ohio       2         3  01085497    39         OH   \n",
-       "36              Oklahoma       3         7  01102857    40         OK   \n",
-       "37                Oregon       4         9  01155107    41         OR   \n",
-       "38          Pennsylvania       1         2  01779798    42         PA   \n",
-       "39          Rhode Island       1         1  01219835    44         RI   \n",
-       "40        South Carolina       3         5  01779799    45         SC   \n",
-       "41          South Dakota       2         4  01785534    46         SD   \n",
-       "42             Tennessee       3         6  01325873    47         TN   \n",
-       "43                 Texas       3         7  01779801    48         TX   \n",
-       "44                  Utah       4         8  01455989    49         UT   \n",
-       "45               Vermont       1         1  01779802    50         VT   \n",
-       "46              Virginia       3         5  01779803    51         VA   \n",
-       "47            Washington       4         9  01779804    53         WA   \n",
-       "48         West Virginia       3         5  01779805    54         WV   \n",
-       "49             Wisconsin       2         3  01779806    55         WI   \n",
-       "50               Wyoming       4         8  01779807    56         WY   \n",
+       "                   state state_usps  region  division   statens geoid  \\\n",
+       "0                Alabama         AL       3         6  01779775    01   \n",
+       "1                 Alaska         AK       4         9  01785533    02   \n",
+       "2                Arizona         AZ       4         8  01779777    04   \n",
+       "3               Arkansas         AR       3         7  00068085    05   \n",
+       "4             California         CA       4         9  01779778    06   \n",
+       "5               Colorado         CO       4         8  01779779    08   \n",
+       "6            Connecticut         CT       1         1  01779780    09   \n",
+       "7               Delaware         DE       3         5  01779781    10   \n",
+       "8   District of Columbia         DC       3         5  01702382    11   \n",
+       "9                Florida         FL       3         5  00294478    12   \n",
+       "10               Georgia         GA       3         5  01705317    13   \n",
+       "11                Hawaii         HI       4         9  01779782    15   \n",
+       "12                 Idaho         ID       4         8  01779783    16   \n",
+       "13              Illinois         IL       2         3  01779784    17   \n",
+       "14               Indiana         IN       2         3  00448508    18   \n",
+       "15                  Iowa         IA       2         4  01779785    19   \n",
+       "16                Kansas         KS       2         4  00481813    20   \n",
+       "17              Kentucky         KY       3         6  01779786    21   \n",
+       "18             Louisiana         LA       3         7  01629543    22   \n",
+       "19                 Maine         ME       1         1  01779787    23   \n",
+       "20              Maryland         MD       3         5  01714934    24   \n",
+       "21         Massachusetts         MA       1         1  00606926    25   \n",
+       "22              Michigan         MI       2         3  01779789    26   \n",
+       "23             Minnesota         MN       2         4  00662849    27   \n",
+       "24           Mississippi         MS       3         6  01779790    28   \n",
+       "25              Missouri         MO       2         4  01779791    29   \n",
+       "26               Montana         MT       4         8  00767982    30   \n",
+       "27              Nebraska         NE       2         4  01779792    31   \n",
+       "28                Nevada         NV       4         8  01779793    32   \n",
+       "29         New Hampshire         NH       1         1  01779794    33   \n",
+       "30            New Jersey         NJ       1         2  01779795    34   \n",
+       "31            New Mexico         NM       4         8  00897535    35   \n",
+       "32              New York         NY       1         2  01779796    36   \n",
+       "33        North Carolina         NC       3         5  01027616    37   \n",
+       "34          North Dakota         ND       2         4  01779797    38   \n",
+       "35                  Ohio         OH       2         3  01085497    39   \n",
+       "36              Oklahoma         OK       3         7  01102857    40   \n",
+       "37                Oregon         OR       4         9  01155107    41   \n",
+       "38          Pennsylvania         PA       1         2  01779798    42   \n",
+       "39          Rhode Island         RI       1         1  01219835    44   \n",
+       "40        South Carolina         SC       3         5  01779799    45   \n",
+       "41          South Dakota         SD       2         4  01785534    46   \n",
+       "42             Tennessee         TN       3         6  01325873    47   \n",
+       "43                 Texas         TX       3         7  01779801    48   \n",
+       "44                  Utah         UT       4         8  01455989    49   \n",
+       "45               Vermont         VT       1         1  01779802    50   \n",
+       "46              Virginia         VA       3         5  01779803    51   \n",
+       "47            Washington         WA       4         9  01779804    53   \n",
+       "48         West Virginia         WV       3         5  01779805    54   \n",
+       "49             Wisconsin         WI       2         3  01779806    55   \n",
+       "50               Wyoming         WY       4         8  01779807    56   \n",
        "\n",
        "        area_land    area_water   latitude   longitude  \n",
        "0    131174192284    4593183334  32.739632  -86.843459  \n",
@@ -6994,7 +7050,7 @@
        "50   251458578211    1867637632  42.989659 -107.544392  "
       ]
      },
-     "execution_count": 1564,
+     "execution_count": 192,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -7005,7 +7061,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1565,
+   "execution_count": 193,
    "metadata": {},
    "outputs": [
     {
@@ -7022,7 +7078,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1566,
+   "execution_count": 194,
    "metadata": {},
    "outputs": [
     {
@@ -7065,7 +7121,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1533,
+   "execution_count": 195,
    "metadata": {
     "tags": []
    },
@@ -7116,7 +7172,7 @@
        "Name: state_count, dtype: int64"
       ]
      },
-     "execution_count": 1533,
+     "execution_count": 195,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -7132,7 +7188,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1534,
+   "execution_count": 196,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -7141,7 +7197,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1535,
+   "execution_count": 197,
    "metadata": {},
    "outputs": [
     {
@@ -7171,7 +7227,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1536,
+   "execution_count": 198,
    "metadata": {},
    "outputs": [
     {
@@ -7323,7 +7379,7 @@
        "9     Illinois                     24  24  0  0.0 NaN  1892"
       ]
      },
-     "execution_count": 1536,
+     "execution_count": 198,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -7342,7 +7398,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1537,
+   "execution_count": 199,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -7352,7 +7408,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1538,
+   "execution_count": 200,
    "metadata": {},
    "outputs": [
     {
@@ -7380,7 +7436,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1539,
+   "execution_count": 201,
    "metadata": {},
    "outputs": [
     {
@@ -7406,7 +7462,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1540,
+   "execution_count": 202,
    "metadata": {},
    "outputs": [
     {
@@ -7426,7 +7482,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1541,
+   "execution_count": 203,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -7435,7 +7491,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1542,
+   "execution_count": 204,
    "metadata": {},
    "outputs": [
     {
@@ -7478,7 +7534,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1543,
+   "execution_count": 205,
    "metadata": {},
    "outputs": [
     {
@@ -7505,7 +7561,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1544,
+   "execution_count": 206,
    "metadata": {},
    "outputs": [
     {
@@ -7524,7 +7580,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1545,
+   "execution_count": 207,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -7534,7 +7590,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1546,
+   "execution_count": 208,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -7544,7 +7600,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1547,
+   "execution_count": 209,
    "metadata": {},
    "outputs": [
     {
@@ -7572,7 +7628,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1548,
+   "execution_count": 210,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -7581,7 +7637,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1549,
+   "execution_count": 211,
    "metadata": {},
    "outputs": [
     {
@@ -7619,7 +7675,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1550,
+   "execution_count": 212,
    "metadata": {},
    "outputs": [
     {
@@ -7663,7 +7719,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1569,
+   "execution_count": 213,
    "metadata": {},
    "outputs": [
     {
@@ -7698,7 +7754,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1570,
+   "execution_count": 214,
    "metadata": {},
    "outputs": [
     {
@@ -7710,7 +7766,7 @@
        "Name: _merge, dtype: int64"
       ]
      },
-     "execution_count": 1570,
+     "execution_count": 214,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -7730,7 +7786,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1575,
+   "execution_count": 215,
    "metadata": {},
    "outputs": [
     {
@@ -7752,15 +7808,15 @@
       " 7   candidate_id               3954 non-null   int64   \n",
       " 8   name                       3954 non-null   object  \n",
       " 9   _merge                     3954 non-null   category\n",
-      " 10  is_total                   3954 non-null   int64   \n",
-      "dtypes: category(1), int64(4), object(6)\n",
+      " 10  is_total                   3954 non-null   object  \n",
+      "dtypes: category(1), int64(3), object(7)\n",
       "memory usage: 343.8+ KB\n"
      ]
     }
    ],
    "source": [
     "votes_df.loc[votes_df['_merge']=='left_only', 'state'] = None\n",
-    "votes_df['is_total'] = votes_df['_merge'].map(lambda x: 1 if x == 'left_only' else 0)\n",
+    "votes_df['is_total'] = votes_df['_merge'].map(lambda x: True if x == 'left_only' else False)\n",
     "votes_df.info()"
    ]
   },
@@ -7774,7 +7830,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1577,
+   "execution_count": 216,
    "metadata": {},
    "outputs": [
     {
@@ -7792,8 +7848,8 @@
       " 3   col_ind                    3954 non-null   object\n",
       " 4   president_electoral_votes  3954 non-null   int64 \n",
       " 5   candidate_id               3954 non-null   int64 \n",
-      " 6   is_total                   3954 non-null   int64 \n",
-      "dtypes: int64(4), object(3)\n",
+      " 6   is_total                   3954 non-null   object\n",
+      "dtypes: int64(3), object(4)\n",
       "memory usage: 247.1+ KB\n"
      ]
     }
@@ -7816,7 +7872,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1579,
+   "execution_count": 217,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -7828,7 +7884,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1580,
+   "execution_count": 218,
    "metadata": {},
    "outputs": [
     {
@@ -7846,9 +7902,9 @@
       " 3   col_ind                    3954 non-null   object\n",
       " 4   president_electoral_votes  3954 non-null   int64 \n",
       " 5   candidate_id               3954 non-null   int64 \n",
-      " 6   is_total                   3954 non-null   int64 \n",
+      " 6   is_total                   3954 non-null   object\n",
       " 7   president_electoral_rank   3954 non-null   int64 \n",
-      "dtypes: int64(5), object(3)\n",
+      "dtypes: int64(4), object(4)\n",
       "memory usage: 278.0+ KB\n"
      ]
     }
@@ -7860,7 +7916,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1581,
+   "execution_count": 219,
    "metadata": {},
    "outputs": [
     {
@@ -7919,7 +7975,7 @@
        "3902  2016       3                         2"
       ]
      },
-     "execution_count": 1581,
+     "execution_count": 219,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -7932,7 +7988,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1582,
+   "execution_count": 220,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -7948,7 +8004,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1584,
+   "execution_count": 221,
    "metadata": {},
    "outputs": [
     {
@@ -7965,16 +8021,16 @@
       " 2   total_electoral_votes      3954 non-null   int64 \n",
       " 3   president_electoral_votes  3954 non-null   int64 \n",
       " 4   candidate_id               3954 non-null   int64 \n",
-      " 5   is_total                   3954 non-null   int64 \n",
+      " 5   is_total                   3954 non-null   bool  \n",
       " 6   president_electoral_rank   3954 non-null   int64 \n",
-      "dtypes: int64(6), object(1)\n",
-      "memory usage: 247.1+ KB\n"
+      "dtypes: bool(1), int64(5), object(1)\n",
+      "memory usage: 220.1+ KB\n"
      ]
     }
    ],
    "source": [
     "# 'state_id' must remain float type due to presence of NaN values\n",
-    "votes_df = votes_df.astype({'year': 'int'}, copy=False)\n",
+    "votes_df = votes_df.astype({'year': 'int', 'is_total': 'bool'}, copy=False)\n",
     "votes_df.info()"
    ]
   },
@@ -7987,7 +8043,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1585,
+   "execution_count": 222,
    "metadata": {},
    "outputs": [
     {
@@ -8001,13 +8057,13 @@
       "---  ------                     --------------  ----- \n",
       " 0   year                       3954 non-null   int64 \n",
       " 1   state                      3875 non-null   object\n",
-      " 2   is_total                   3954 non-null   int64 \n",
+      " 2   is_total                   3954 non-null   bool  \n",
       " 3   candidate_id               3954 non-null   int64 \n",
-      " 4   president_electoral_rank   3954 non-null   int64 \n",
-      " 5   total_electoral_votes      3954 non-null   int64 \n",
-      " 6   president_electoral_votes  3954 non-null   int64 \n",
-      "dtypes: int64(6), object(1)\n",
-      "memory usage: 247.1+ KB\n"
+      " 4   total_electoral_votes      3954 non-null   int64 \n",
+      " 5   president_electoral_votes  3954 non-null   int64 \n",
+      " 6   president_electoral_rank   3954 non-null   int64 \n",
+      "dtypes: bool(1), int64(5), object(1)\n",
+      "memory usage: 220.1+ KB\n"
      ]
     }
    ],
@@ -8025,7 +8081,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1586,
+   "execution_count": 223,
    "metadata": {},
    "outputs": [
     {
@@ -8053,9 +8109,9 @@
        "      <th>state</th>\n",
        "      <th>is_total</th>\n",
        "      <th>candidate_id</th>\n",
-       "      <th>president_electoral_rank</th>\n",
        "      <th>total_electoral_votes</th>\n",
        "      <th>president_electoral_votes</th>\n",
+       "      <th>president_electoral_rank</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
@@ -8063,73 +8119,73 @@
        "      <th>0</th>\n",
        "      <td>1892</td>\n",
        "      <td>Alabama</td>\n",
-       "      <td>0</td>\n",
-       "      <td>1</td>\n",
+       "      <td>False</td>\n",
        "      <td>1</td>\n",
        "      <td>11</td>\n",
        "      <td>11</td>\n",
+       "      <td>1</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
        "      <td>1892</td>\n",
        "      <td>Alabama</td>\n",
-       "      <td>0</td>\n",
-       "      <td>2</td>\n",
+       "      <td>False</td>\n",
        "      <td>2</td>\n",
        "      <td>11</td>\n",
        "      <td>0</td>\n",
+       "      <td>2</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
        "      <td>1892</td>\n",
        "      <td>Alabama</td>\n",
-       "      <td>0</td>\n",
-       "      <td>3</td>\n",
+       "      <td>False</td>\n",
        "      <td>3</td>\n",
        "      <td>11</td>\n",
        "      <td>0</td>\n",
+       "      <td>3</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
        "      <td>1892</td>\n",
        "      <td>Arkansas</td>\n",
-       "      <td>0</td>\n",
-       "      <td>1</td>\n",
+       "      <td>False</td>\n",
        "      <td>1</td>\n",
        "      <td>8</td>\n",
        "      <td>8</td>\n",
+       "      <td>1</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
        "      <td>1892</td>\n",
        "      <td>Arkansas</td>\n",
-       "      <td>0</td>\n",
-       "      <td>2</td>\n",
+       "      <td>False</td>\n",
        "      <td>2</td>\n",
        "      <td>8</td>\n",
        "      <td>0</td>\n",
+       "      <td>2</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "   year     state  is_total  candidate_id  president_electoral_rank  \\\n",
-       "0  1892   Alabama         0             1                         1   \n",
-       "1  1892   Alabama         0             2                         2   \n",
-       "2  1892   Alabama         0             3                         3   \n",
-       "3  1892  Arkansas         0             1                         1   \n",
-       "4  1892  Arkansas         0             2                         2   \n",
+       "   year     state  is_total  candidate_id  total_electoral_votes  \\\n",
+       "0  1892   Alabama     False             1                     11   \n",
+       "1  1892   Alabama     False             2                     11   \n",
+       "2  1892   Alabama     False             3                     11   \n",
+       "3  1892  Arkansas     False             1                      8   \n",
+       "4  1892  Arkansas     False             2                      8   \n",
        "\n",
-       "   total_electoral_votes  president_electoral_votes  \n",
-       "0                     11                         11  \n",
-       "1                     11                          0  \n",
-       "2                     11                          0  \n",
-       "3                      8                          8  \n",
-       "4                      8                          0  "
+       "   president_electoral_votes  president_electoral_rank  \n",
+       "0                         11                         1  \n",
+       "1                          0                         2  \n",
+       "2                          0                         3  \n",
+       "3                          8                         1  \n",
+       "4                          0                         2  "
       ]
      },
-     "execution_count": 1586,
+     "execution_count": 223,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -8149,7 +8205,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1587,
+   "execution_count": 224,
    "metadata": {},
    "outputs": [
     {
@@ -8178,9 +8234,9 @@
        "      <th>state</th>\n",
        "      <th>is_total</th>\n",
        "      <th>candidate_id</th>\n",
-       "      <th>president_electoral_rank</th>\n",
        "      <th>total_electoral_votes</th>\n",
        "      <th>president_electoral_votes</th>\n",
+       "      <th>president_electoral_rank</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
@@ -8189,77 +8245,77 @@
        "      <td>1</td>\n",
        "      <td>1892</td>\n",
        "      <td>Alabama</td>\n",
-       "      <td>0</td>\n",
-       "      <td>1</td>\n",
+       "      <td>False</td>\n",
        "      <td>1</td>\n",
        "      <td>11</td>\n",
        "      <td>11</td>\n",
+       "      <td>1</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
        "      <td>2</td>\n",
        "      <td>1892</td>\n",
        "      <td>Alabama</td>\n",
-       "      <td>0</td>\n",
-       "      <td>2</td>\n",
+       "      <td>False</td>\n",
        "      <td>2</td>\n",
        "      <td>11</td>\n",
        "      <td>0</td>\n",
+       "      <td>2</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
        "      <td>3</td>\n",
        "      <td>1892</td>\n",
        "      <td>Alabama</td>\n",
-       "      <td>0</td>\n",
-       "      <td>3</td>\n",
+       "      <td>False</td>\n",
        "      <td>3</td>\n",
        "      <td>11</td>\n",
        "      <td>0</td>\n",
+       "      <td>3</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
        "      <td>4</td>\n",
        "      <td>1892</td>\n",
        "      <td>Arkansas</td>\n",
-       "      <td>0</td>\n",
-       "      <td>1</td>\n",
+       "      <td>False</td>\n",
        "      <td>1</td>\n",
        "      <td>8</td>\n",
        "      <td>8</td>\n",
+       "      <td>1</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
        "      <td>5</td>\n",
        "      <td>1892</td>\n",
        "      <td>Arkansas</td>\n",
-       "      <td>0</td>\n",
-       "      <td>2</td>\n",
+       "      <td>False</td>\n",
        "      <td>2</td>\n",
        "      <td>8</td>\n",
        "      <td>0</td>\n",
+       "      <td>2</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "   votes_id  year     state  is_total  candidate_id  president_electoral_rank  \\\n",
-       "0         1  1892   Alabama         0             1                         1   \n",
-       "1         2  1892   Alabama         0             2                         2   \n",
-       "2         3  1892   Alabama         0             3                         3   \n",
-       "3         4  1892  Arkansas         0             1                         1   \n",
-       "4         5  1892  Arkansas         0             2                         2   \n",
+       "   votes_id  year     state  is_total  candidate_id  total_electoral_votes  \\\n",
+       "0         1  1892   Alabama     False             1                     11   \n",
+       "1         2  1892   Alabama     False             2                     11   \n",
+       "2         3  1892   Alabama     False             3                     11   \n",
+       "3         4  1892  Arkansas     False             1                      8   \n",
+       "4         5  1892  Arkansas     False             2                      8   \n",
        "\n",
-       "   total_electoral_votes  president_electoral_votes  \n",
-       "0                     11                         11  \n",
-       "1                     11                          0  \n",
-       "2                     11                          0  \n",
-       "3                      8                          8  \n",
-       "4                      8                          0  "
+       "   president_electoral_votes  president_electoral_rank  \n",
+       "0                         11                         1  \n",
+       "1                          0                         2  \n",
+       "2                          0                         3  \n",
+       "3                          8                         1  \n",
+       "4                          0                         2  "
       ]
      },
-     "execution_count": 1587,
+     "execution_count": 224,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -8281,7 +8337,38 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1588,
+   "execution_count": 225,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<class 'pandas.core.frame.DataFrame'>\n",
+      "RangeIndex: 3954 entries, 0 to 3953\n",
+      "Data columns (total 8 columns):\n",
+      " #   Column                     Non-Null Count  Dtype \n",
+      "---  ------                     --------------  ----- \n",
+      " 0   votes_id                   3954 non-null   int64 \n",
+      " 1   year                       3954 non-null   int64 \n",
+      " 2   state                      3875 non-null   object\n",
+      " 3   is_total                   3954 non-null   bool  \n",
+      " 4   candidate_id               3954 non-null   int64 \n",
+      " 5   total_electoral_votes      3954 non-null   int64 \n",
+      " 6   president_electoral_votes  3954 non-null   int64 \n",
+      " 7   president_electoral_rank   3954 non-null   int64 \n",
+      "dtypes: bool(1), int64(6), object(1)\n",
+      "memory usage: 220.2+ KB\n"
+     ]
+    }
+   ],
+   "source": [
+    "votes_df.info()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 226,
    "metadata": {},
    "outputs": [
     {
@@ -8299,7 +8386,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1589,
+   "execution_count": 227,
    "metadata": {},
    "outputs": [
     {
@@ -8313,13 +8400,13 @@
    "source": [
     "# This count INCLUDES the state totals for each election year and candidate\n",
     "final_year_state_count = votes_df[votes_df['president_electoral_rank']==1].groupby('year')['state'].size()\n",
-    "year_state_count = pd.merge(left=initial_state_count, right=final_year_state_count, left_index=True, right_index=True)\n",
+    "year_state_count = pd.merge(left=initial_year_state_count, right=final_year_state_count, left_index=True, right_index=True)\n",
     "print(f\"Q: Are the Initial and Final State Counts by Year Equivalent? A: {(year_state_count['state']==year_state_count['state_count']).all()}\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 1590,
+   "execution_count": 228,
    "metadata": {},
    "outputs": [
     {
@@ -8350,31 +8437,38 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 111,
+   "execution_count": 244,
    "metadata": {},
    "outputs": [],
    "source": [
-    "# column_names = ['year', 'state', 'president_candidate_name', 'president_candidate_party', 'president_candidate_state', \\\n",
-    "#                 'president_electoral_votes', 'president_electoral_rank', 'president_popular_votes', 'president_popular_rank']\n",
-    "# data_df = pd.DataFrame(columns=column_names)\n",
-    "# data_df.info()\n",
-    "# Define functions/classes specific to this notebook\n",
-    "def create_table_from_csv(dbc, schema, table_name, table_columns, csv_path):\n",
-    "    \"\"\"This function builds a new schema, schema, in a postgres db using the\n",
-    "    input psycopg2 connection, dbc, then builds a table, table_name, using\n",
-    "    the table column definitions in table_columns, and finally populates the table\n",
-    "    with data from the csv file located at csv_path\n",
-    "    \"\"\"\n",
-    "    dbc.create_schema(schema, replace=True)\n",
-    "    dbc.create_table(schema, table_name, table_columns, replace=True)\n",
-    "    #dbc.copy_csv_to_table(schema, table_name, csv_path)\n"
+    "# Use this to reload DBC class if changes have been made to it, \n",
+    "# and you don't want to restart the kernel...\n",
+    "# import importlib\n",
+    "# import sys\n",
+    "# importlib.reload(sys.modules['db_tools'])\n",
+    "# from db_tools import DBC"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 4.1 Define DB Connection, Schema, and Table Parameters"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 253,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdin",
+     "output_type": "stream",
+     "text": [
+      " ·········\n"
+     ]
+    }
+   ],
    "source": [
     "# Define parameters for database connection, schema name, table name, and column definitions\n",
     "# Obfuscate password using getpass\n",
@@ -8385,61 +8479,97 @@
     "    'dbname': 'elections',\n",
     "    'password': getpass.getpass()\n",
     "}\n",
-    "# Data Warehouse\n",
+    "# Data Warehouse schema\n",
     "schema = 'dwh'\n",
-    "table_names = ['candidate', 'state', 'votes']\n",
-    "# Define each column's name, type, and optionally constraint(s): one tuple per column \n",
-    "table_columns = [\n",
-    "                    [  # Candidate\n",
-    "                    ('id', 'smallint', 'primary key'),\n",
-    "                    ('name', 'varchar', 'unique not null'),\n",
-    "                    ('name_first', 'varchar', 'not null'),\n",
-    "                    ('name_middle', 'varchar'),\n",
-    "                    ('name_last', 'varchar'),\n",
-    "                    ('name_suffix', 'varchar'),\n",
-    "                    ('state', 'varchar'),\n",
-    "                    ('state_2', 'varchar'),\n",
-    "                    ('party', 'varchar'),\n",
-    "                    ('party_2', 'varchar')\n",
-    "                    ],\n",
-    "0   candidate_id  55 non-null     int64 \n",
-    " 1   name          55 non-null     object\n",
-    " 2   name_first    55 non-null     object\n",
-    " 3   name_middle   35 non-null     object\n",
-    " 4   name_last     54 non-null     object\n",
-    " 5   name_suffix   2 non-null      object\n",
-    " 6   state         54 non-null     object\n",
-    " 7   state_2       2 non-null      object\n",
-    " 8   party         45 non-null     object\n",
-    " 9   party_2       2 non-null      object\n",
-    "                     \n",
-    "                 ('measure_id', 'smallint'),\n",
-    "                 ('numerator', 'numeric'),\n",
-    "                 ('denominator', 'numeric'),\n",
-    "                 ('raw_value', 'numeric'),\n",
-    "                 ('confidence_interval_lower', 'numeric'),\n",
-    "                 ('confidence_interval_upper', 'numeric'),\n",
-    "                 ('data_release_year', 'smallint'),\n",
-    "                 ('fips_code', 'integer')]\n"
+    "# Name of each table to create\n",
+    "table_names = ['state', 'candidate', 'votes']\n",
+    "# Define each column's name, type, and optionally constraint(s):\n",
+    "# one tuple per column + table constraint(s) at the end\n",
+    "# Must be in same order as table_names\n",
+    "table_column_defs = [\n",
+    "    [   #  State Dimension Table\n",
+    "        ('state', 'varchar', 'primary key'),\n",
+    "        ('state_usps', 'varchar(2)', 'not null'),\n",
+    "        ('region', 'smallint', 'not null'),\n",
+    "        ('division', 'smallint', 'not null'),\n",
+    "        ('statens', 'varchar', 'not null'),\n",
+    "        ('geoid', 'varchar', 'not null'),\n",
+    "        ('area_land', 'bigint', 'not null'),\n",
+    "        ('area_water', 'bigint', 'not null'),\n",
+    "        ('latitude', 'numeric', 'not null'),\n",
+    "        ('longitude', 'numeric', 'not null')\n",
+    "    ],\n",
+    "    [   # Candidate Dimension Table\n",
+    "        ('candidate_id', 'smallint', 'primary key'),\n",
+    "        ('name', 'varchar', 'not null'),\n",
+    "        ('name_first', 'varchar', 'not null'),\n",
+    "        ('name_middle', 'varchar'),\n",
+    "        ('name_last', 'varchar'),\n",
+    "        ('name_suffix', 'varchar'),\n",
+    "        ('state', 'varchar', 'REFERENCES dwh.state (state)'),\n",
+    "        ('state_2', 'varchar', 'REFERENCES dwh.state (state)'),\n",
+    "        ('party', 'varchar'),\n",
+    "        ('party_2', 'varchar')\n",
+    "    ],\n",
+    "    [   # Votes Fact Table\n",
+    "        ('votes_id', 'integer', 'primary key'),\n",
+    "        ('year', 'smallint', 'not null'),\n",
+    "        ('state', 'varchar', 'REFERENCES dwh.state (state)'),\n",
+    "        ('is_total', 'boolean', 'not null'),\n",
+    "        ('candidate_id', 'smallint', 'not null', 'REFERENCES dwh.candidate (candidate_id)'),\n",
+    "        ('total_electoral_votes', 'smallint', 'not null'),\n",
+    "        ('president_electoral_votes', 'smallint', 'not null'),\n",
+    "        ('president_electoral_rank', 'smallint', 'not null')\n",
+    "    ]\n",
+    "]"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 4.1 Create connection class"
+    "### 4.2 Connect to Database via DBC Class"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 254,
    "metadata": {},
    "outputs": [],
    "source": [
     "# Database connection instance for interacting with postgres database\n",
     "# See db_tools.py for class definition\n",
-    "# Connection must be closed with close flag or by calling close_connection()\n",
+    "# Note: Connection must be closed with close flag or by calling close_connection()\n",
     "dbc = DBC(db_config)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 4.3 Write Candidate, State, and Votes data to Postgres Database"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 255,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Creating Schema: dwh\n",
+      "Creating Table: dwh.state\n",
+      "Creating Table: dwh.candidate\n",
+      "Creating Table: dwh.votes\n",
+      "All Data Successfully Inserted!!!\n"
+     ]
+    }
+   ],
+   "source": [
+    "dfs = [state_df, candidates_df, votes_df]\n",
+    "create_tables_from_dfs(dbc, schema, table_names, table_column_defs, dfs, replace=True, close=True)"
    ]
   },
   {
@@ -8447,23 +8577,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# Define each column's name and type, one tuple per column \n",
-    "table_columns = [('state', 'varchar(2)'),\n",
-    "                 ('county', 'varchar'),\n",
-    "                 ('state_code', 'smallint'),\n",
-    "                 ('county_code', 'smallint'),\n",
-    "                 ('year_span', 'varchar(9)'),\n",
-    "                 ('measure_name', 'varchar'),\n",
-    "                 ('measure_id', 'smallint'),\n",
-    "                 ('numerator', 'numeric'),\n",
-    "                 ('denominator', 'numeric'),\n",
-    "                 ('raw_value', 'numeric'),\n",
-    "                 ('confidence_interval_lower', 'numeric'),\n",
-    "                 ('confidence_interval_upper', 'numeric'),\n",
-    "                 ('data_release_year', 'smallint'),\n",
-    "                 ('fips_code', 'integer')]"
-   ]
+   "source": []
   }
  ],
  "metadata": {

--- a/step1_electoral_college_data.ipynb
+++ b/step1_electoral_college_data.ipynb
@@ -21,7 +21,7 @@
     "    2. Transform and Validate Candidate Data\n",
     "    3. Transform and Validate State Data\n",
     "    4. Transform and Validate Electoral Votes Data\n",
-    "4. [ ] Write Election Data Tables to Postgres\n",
+    "4. [X] Write Election Data Tables to Postgres\n",
     "\n",
     "### Notes\n",
     "- The National Archives website only contains Electoral College results for US Presidential Elections from 1892 to present. Another data source will be scraped to get Popular Vote data for each Presidential Election\n",
@@ -77,7 +77,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 252,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5697,7 +5697,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 178,
+   "execution_count": 69,
    "metadata": {},
    "outputs": [
     {
@@ -5722,7 +5722,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 179,
+   "execution_count": 70,
    "metadata": {},
    "outputs": [
     {
@@ -5741,7 +5741,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 180,
+   "execution_count": 71,
    "metadata": {},
    "outputs": [
     {
@@ -5802,7 +5802,7 @@
        "4  California"
       ]
      },
-     "execution_count": 180,
+     "execution_count": 71,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -5825,7 +5825,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 181,
+   "execution_count": 72,
    "metadata": {},
    "outputs": [
     {
@@ -5863,7 +5863,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 182,
+   "execution_count": 73,
    "metadata": {},
    "outputs": [
     {
@@ -6022,7 +6022,7 @@
        "4  POLYGON ((-77.45881 39.22027, -77.45866 39.220...  "
       ]
      },
-     "execution_count": 182,
+     "execution_count": 73,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -6033,7 +6033,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 183,
+   "execution_count": 74,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -6043,7 +6043,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 184,
+   "execution_count": 75,
    "metadata": {},
    "outputs": [
     {
@@ -6084,7 +6084,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 185,
+   "execution_count": 76,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -6093,7 +6093,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 186,
+   "execution_count": 77,
    "metadata": {},
    "outputs": [
     {
@@ -6134,7 +6134,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 187,
+   "execution_count": 78,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -6154,7 +6154,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 188,
+   "execution_count": 79,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -6163,7 +6163,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 190,
+   "execution_count": 80,
    "metadata": {},
    "outputs": [
     {
@@ -6205,7 +6205,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 191,
+   "execution_count": 81,
    "metadata": {},
    "outputs": [
     {
@@ -6238,7 +6238,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 192,
+   "execution_count": 82,
    "metadata": {},
    "outputs": [
     {
@@ -7050,7 +7050,7 @@
        "50   251458578211    1867637632  42.989659 -107.544392  "
       ]
      },
-     "execution_count": 192,
+     "execution_count": 82,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -7061,7 +7061,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 193,
+   "execution_count": 83,
    "metadata": {},
    "outputs": [
     {
@@ -7078,7 +7078,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 194,
+   "execution_count": 84,
    "metadata": {},
    "outputs": [
     {
@@ -7121,7 +7121,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 195,
+   "execution_count": 85,
    "metadata": {
     "tags": []
    },
@@ -7172,7 +7172,7 @@
        "Name: state_count, dtype: int64"
       ]
      },
-     "execution_count": 195,
+     "execution_count": 85,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -7188,7 +7188,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 196,
+   "execution_count": 86,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -7197,7 +7197,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 197,
+   "execution_count": 87,
    "metadata": {},
    "outputs": [
     {
@@ -7227,7 +7227,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 198,
+   "execution_count": 88,
    "metadata": {},
    "outputs": [
     {
@@ -7379,7 +7379,7 @@
        "9     Illinois                     24  24  0  0.0 NaN  1892"
       ]
      },
-     "execution_count": 198,
+     "execution_count": 88,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -7398,7 +7398,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 199,
+   "execution_count": 89,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -7408,7 +7408,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 200,
+   "execution_count": 90,
    "metadata": {},
    "outputs": [
     {
@@ -7436,7 +7436,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 201,
+   "execution_count": 91,
    "metadata": {},
    "outputs": [
     {
@@ -7462,7 +7462,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 202,
+   "execution_count": 92,
    "metadata": {},
    "outputs": [
     {
@@ -7482,7 +7482,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 203,
+   "execution_count": 93,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -7491,7 +7491,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 204,
+   "execution_count": 94,
    "metadata": {},
    "outputs": [
     {
@@ -7534,7 +7534,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 205,
+   "execution_count": 95,
    "metadata": {},
    "outputs": [
     {
@@ -7561,14 +7561,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 206,
+   "execution_count": 96,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "set()\n"
+      "{'Donald Trump', 'George McGovern'}\n"
      ]
     }
    ],
@@ -7580,7 +7580,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 207,
+   "execution_count": 97,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -7590,7 +7590,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 208,
+   "execution_count": 98,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -7600,7 +7600,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 209,
+   "execution_count": 99,
    "metadata": {},
    "outputs": [
     {
@@ -7628,7 +7628,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 210,
+   "execution_count": 100,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -7637,7 +7637,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 211,
+   "execution_count": 101,
    "metadata": {},
    "outputs": [
     {
@@ -7675,7 +7675,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 212,
+   "execution_count": 102,
    "metadata": {},
    "outputs": [
     {
@@ -7719,7 +7719,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 213,
+   "execution_count": 103,
    "metadata": {},
    "outputs": [
     {
@@ -7754,7 +7754,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 214,
+   "execution_count": 104,
    "metadata": {},
    "outputs": [
     {
@@ -7766,7 +7766,7 @@
        "Name: _merge, dtype: int64"
       ]
      },
-     "execution_count": 214,
+     "execution_count": 104,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -7786,7 +7786,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 215,
+   "execution_count": 105,
    "metadata": {},
    "outputs": [
     {
@@ -7830,7 +7830,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 216,
+   "execution_count": 106,
    "metadata": {},
    "outputs": [
     {
@@ -7872,7 +7872,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 217,
+   "execution_count": 107,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -7884,7 +7884,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 218,
+   "execution_count": 108,
    "metadata": {},
    "outputs": [
     {
@@ -7916,7 +7916,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 219,
+   "execution_count": 109,
    "metadata": {},
    "outputs": [
     {
@@ -7975,7 +7975,7 @@
        "3902  2016       3                         2"
       ]
      },
-     "execution_count": 219,
+     "execution_count": 109,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -7988,7 +7988,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 220,
+   "execution_count": 110,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -8004,7 +8004,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 221,
+   "execution_count": 111,
    "metadata": {},
    "outputs": [
     {
@@ -8043,7 +8043,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 222,
+   "execution_count": 112,
    "metadata": {},
    "outputs": [
     {
@@ -8081,7 +8081,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 223,
+   "execution_count": 113,
    "metadata": {},
    "outputs": [
     {
@@ -8185,7 +8185,7 @@
        "4                          0                         2  "
       ]
      },
-     "execution_count": 223,
+     "execution_count": 113,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -8205,7 +8205,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 224,
+   "execution_count": 114,
    "metadata": {},
    "outputs": [
     {
@@ -8315,7 +8315,7 @@
        "4                          0                         2  "
       ]
      },
-     "execution_count": 224,
+     "execution_count": 114,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -8337,7 +8337,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 225,
+   "execution_count": 115,
    "metadata": {},
    "outputs": [
     {
@@ -8368,7 +8368,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 226,
+   "execution_count": 116,
    "metadata": {},
    "outputs": [
     {
@@ -8386,7 +8386,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 227,
+   "execution_count": 117,
    "metadata": {},
    "outputs": [
     {
@@ -8406,7 +8406,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 228,
+   "execution_count": 118,
    "metadata": {},
    "outputs": [
     {
@@ -8436,20 +8436,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 244,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Use this to reload DBC class if changes have been made to it, \n",
-    "# and you don't want to restart the kernel...\n",
-    "# import importlib\n",
-    "# import sys\n",
-    "# importlib.reload(sys.modules['db_tools'])\n",
-    "# from db_tools import DBC"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -8458,7 +8444,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 253,
+   "execution_count": 119,
    "metadata": {},
    "outputs": [
     {
@@ -8485,7 +8471,9 @@
     "table_names = ['state', 'candidate', 'votes']\n",
     "# Define each column's name, type, and optionally constraint(s):\n",
     "# one tuple per column + table constraint(s) at the end\n",
-    "# Must be in same order as table_names\n",
+    "# Column defs should be listed in the same order as table_names\n",
+    "# Any table with an FK reference must be defined after the\n",
+    "# table it is referencing, as shown below\n",
     "table_column_defs = [\n",
     "    [   #  State Dimension Table\n",
     "        ('state', 'varchar', 'primary key'),\n",
@@ -8506,17 +8494,17 @@
     "        ('name_middle', 'varchar'),\n",
     "        ('name_last', 'varchar'),\n",
     "        ('name_suffix', 'varchar'),\n",
-    "        ('state', 'varchar', 'REFERENCES dwh.state (state)'),\n",
-    "        ('state_2', 'varchar', 'REFERENCES dwh.state (state)'),\n",
+    "        ('state', 'varchar', f'REFERENCES {schema}.{table_names[0]}'),\n",
+    "        ('state_2', 'varchar', f'REFERENCES {schema}.{table_names[0]}'),\n",
     "        ('party', 'varchar'),\n",
     "        ('party_2', 'varchar')\n",
     "    ],\n",
     "    [   # Votes Fact Table\n",
     "        ('votes_id', 'integer', 'primary key'),\n",
     "        ('year', 'smallint', 'not null'),\n",
-    "        ('state', 'varchar', 'REFERENCES dwh.state (state)'),\n",
+    "        ('state', 'varchar', f'REFERENCES {schema}.{table_names[0]}'),\n",
     "        ('is_total', 'boolean', 'not null'),\n",
-    "        ('candidate_id', 'smallint', 'not null', 'REFERENCES dwh.candidate (candidate_id)'),\n",
+    "        ('candidate_id', 'smallint', 'not null', f'REFERENCES {schema}.{table_names[1]}'),\n",
     "        ('total_electoral_votes', 'smallint', 'not null'),\n",
     "        ('president_electoral_votes', 'smallint', 'not null'),\n",
     "        ('president_electoral_rank', 'smallint', 'not null')\n",
@@ -8528,18 +8516,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 4.2 Connect to Database via DBC Class"
+    "### 4.2 Connect to Database via DBC Class\n",
+    "Create a Database Connection (DBC) instance for interacting with the provided postgres database (see db_tools.py for class definition). Note that the connection must be closed using the close flag on one of the instance methods, or by calling dbc.close_connection() explicitly."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 254,
+   "execution_count": 120,
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Database connection instance for interacting with postgres database\n",
-    "# See db_tools.py for class definition\n",
-    "# Note: Connection must be closed with close flag or by calling close_connection()\n",
     "dbc = DBC(db_config)"
    ]
   },
@@ -8547,12 +8533,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 4.3 Write Candidate, State, and Votes data to Postgres Database"
+    "### 4.3 Write State, Candidate, and Votes data to Postgres Database"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 255,
+   "execution_count": 121,
    "metadata": {},
    "outputs": [
     {


### PR DESCRIPTION
Write the state and candidate dimension tables, and the votes fact table, to postgres database. Also includes a python class definition file `db_tools.py`, which is used to streamline writing the data to postgres.