### PR TITLE
Fix 2000 DC EV data for voter that abstained

### DIFF
--- a/step1_electoral_college_data.ipynb
+++ b/step1_electoral_college_data.ipynb
@@ -26,8 +26,8 @@
     "4. [X] Write Election Data Tables to Postgres\n",
     "\n",
     "**Updated on 1/18/22**: Parse the \"Other\" Candidates for the 2016 Presidential Election using the data in the Notes section of Table 2. \n",
-    "- [ ] Include each Candidate that received at least on Electoral Vote to the Candidate Dimension Table\n",
-    "- [ ] Include the Electoral Votes for each of those new Candidates to the Electoral Vote Fact Table\n",
+    "- [X] Include each Candidate that received at least on Electoral Vote to the Candidate Dimension Table\n",
+    "- [X] Include the Electoral Votes for each of those new Candidates to the Electoral Vote Fact Table\n",
     "\n",
     "### Notes\n",
     "- The National Archives website only contains Electoral College results for US Presidential Elections from 1892 to present. Another data source will be scraped to get Popular Vote data for each Presidential Election\n",
@@ -4501,7 +4501,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'George S. McGovern', 'Bob Dole'}\n"
+      "{'Bob Dole', 'George S. McGovern'}\n"
      ]
     }
    ],
@@ -9393,7 +9393,9 @@
     "- **\"District of Columbia\"**, with a total of 3 but only 2 votes allocated\n",
     "- **\"Totals\"**, with a total of 538 but only 537 votes allocated \n",
     "\n",
-    "I've writting to the National Archive about this issue, so they can fix it. In the meantime, I'm going to manually fix it in the next subsection"
+    "I've writting to the National Archive about this issue, and they confirmed that this data is correct. The response was as follows: \"Those numbers are correct for 2000.  I've made the note on the page more clear - rereading it, it was a little opaque.  DC had 3 electoral votes but one of the electors abstained, so DC only cast 2 of its 3 votes. Since it was the first (and still only) abstention in modern times, and made in conjunction with the 2000 election, it made a fair bit of news.  The elector was Barbara Lett-Simmons if you want to do more research on the backstory.\"\n",
+    "\n",
+    "I've removed my previous fix of this data discrepancy now that it has been confirmed to be accurate."
    ]
   },
   {
@@ -9489,92 +9491,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Fix 2000 Electoral Vote Error for DC and Totals"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 102,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "t2_votes_df.loc[(t2_votes_df['state']==\"District of Columbia\") & (t2_votes_df['year']==2000), 2] = \\\n",
-    "    t2_votes_df.loc[(t2_votes_df['state']==\"District of Columbia\") & (t2_votes_df['year']==2000), 'total_electoral_votes']\n",
-    "t2_votes_df.loc[(t2_votes_df['state']==\"Totals\") & (t2_votes_df['year']==2000), 2] = \\\n",
-    "    t2_votes_df.loc[(t2_votes_df['state']!=\"Totals\") & (t2_votes_df['year']==2000), 2].sum(axis=0)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 103,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>state</th>\n",
-       "      <th>total_electoral_votes</th>\n",
-       "      <th>1</th>\n",
-       "      <th>2</th>\n",
-       "      <th>3</th>\n",
-       "      <th>4</th>\n",
-       "      <th>5</th>\n",
-       "      <th>6</th>\n",
-       "      <th>7</th>\n",
-       "      <th>year</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "Empty DataFrame\n",
-       "Columns: [state, total_electoral_votes, 1, 2, 3, 4, 5, 6, 7, year]\n",
-       "Index: []"
-      ]
-     },
-     "execution_count": 103,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# The two erroneous rows identified in the previous section should be gone now\n",
-    "vote_row_sum = t2_votes_df.loc[:, [1, 2, 3, 4, 5, 6, 7]].sum(axis=1)\n",
-    "t2_votes_df[vote_row_sum!=t2_votes_df['total_electoral_votes']]"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "#### Build Initial Electoral Votes DataFrame\n",
     "Un-pivot the 'col_ind' column so that there is a single column that contains the index corresponding to each Candidate that received at least one Electoral Vote in a given Election Year. This format is required so that the Final Candidate DataFrame can be joined to the Final Electoral Vote DataFrame via the `t2_states_df` DataFrame created in Section 3.2.1, as documented in the following sections."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 104,
+   "execution_count": 102,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -9584,7 +9507,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 105,
+   "execution_count": 103,
    "metadata": {},
    "outputs": [
     {
@@ -9612,7 +9535,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 106,
+   "execution_count": 104,
    "metadata": {},
    "outputs": [
     {
@@ -9638,7 +9561,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 107,
+   "execution_count": 105,
    "metadata": {},
    "outputs": [
     {
@@ -9658,7 +9581,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 108,
+   "execution_count": 106,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -9667,7 +9590,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 109,
+   "execution_count": 107,
    "metadata": {},
    "outputs": [
     {
@@ -9710,7 +9633,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 110,
+   "execution_count": 108,
    "metadata": {},
    "outputs": [
     {
@@ -9737,7 +9660,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 111,
+   "execution_count": 109,
    "metadata": {},
    "outputs": [
     {
@@ -9756,7 +9679,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 112,
+   "execution_count": 110,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -9766,7 +9689,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 113,
+   "execution_count": 111,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -9776,7 +9699,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 114,
+   "execution_count": 112,
    "metadata": {},
    "outputs": [
     {
@@ -9804,7 +9727,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 115,
+   "execution_count": 113,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -9813,7 +9736,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 116,
+   "execution_count": 114,
    "metadata": {},
    "outputs": [
     {
@@ -9851,7 +9774,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 117,
+   "execution_count": 115,
    "metadata": {},
    "outputs": [
     {
@@ -9895,7 +9818,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 118,
+   "execution_count": 116,
    "metadata": {},
    "outputs": [
     {
@@ -9930,7 +9853,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 119,
+   "execution_count": 117,
    "metadata": {},
    "outputs": [
     {
@@ -9942,7 +9865,7 @@
        "Name: _merge, dtype: int64"
       ]
      },
-     "execution_count": 119,
+     "execution_count": 117,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -9962,7 +9885,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 120,
+   "execution_count": 118,
    "metadata": {},
    "outputs": [
     {
@@ -10006,7 +9929,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 121,
+   "execution_count": 119,
    "metadata": {},
    "outputs": [
     {
@@ -10048,7 +9971,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 122,
+   "execution_count": 120,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -10060,7 +9983,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 123,
+   "execution_count": 121,
    "metadata": {},
    "outputs": [
     {
@@ -10092,7 +10015,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 124,
+   "execution_count": 122,
    "metadata": {},
    "outputs": [
     {
@@ -10165,7 +10088,7 @@
        "4058  2016       7                         4"
       ]
      },
-     "execution_count": 124,
+     "execution_count": 122,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -10178,7 +10101,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 125,
+   "execution_count": 123,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -10194,7 +10117,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 126,
+   "execution_count": 124,
    "metadata": {},
    "outputs": [
     {
@@ -10233,7 +10156,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 127,
+   "execution_count": 125,
    "metadata": {},
    "outputs": [
     {
@@ -10271,7 +10194,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 128,
+   "execution_count": 126,
    "metadata": {},
    "outputs": [
     {
@@ -10375,7 +10298,7 @@
        "4                          0                         2  "
       ]
      },
-     "execution_count": 128,
+     "execution_count": 126,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -10395,7 +10318,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 129,
+   "execution_count": 127,
    "metadata": {},
    "outputs": [
     {
@@ -10505,7 +10428,7 @@
        "4                          0                         2  "
       ]
      },
-     "execution_count": 129,
+     "execution_count": 127,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -10527,7 +10450,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 130,
+   "execution_count": 128,
    "metadata": {},
    "outputs": [
     {
@@ -10558,7 +10481,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 131,
+   "execution_count": 129,
    "metadata": {},
    "outputs": [
     {
@@ -10576,7 +10499,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 132,
+   "execution_count": 130,
    "metadata": {},
    "outputs": [
     {
@@ -10596,7 +10519,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 133,
+   "execution_count": 131,
    "metadata": {},
    "outputs": [
     {
@@ -10634,7 +10557,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 134,
+   "execution_count": 132,
    "metadata": {},
    "outputs": [
     {
@@ -10712,7 +10635,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 135,
+   "execution_count": 133,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -10728,7 +10651,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 136,
+   "execution_count": 134,
    "metadata": {},
    "outputs": [
     {


### PR DESCRIPTION
Got confirmation from the National Archives that one elector from the District of Columbia abstained from casting their vote in the 2000 presidential election, so only 2 votes were recorded, and not the total of 3 votes that DC is allocated. This is the first and only time that has happened in US history. 