### PR TITLE
Notebook for Creating Data Mart Object(s)

### DIFF
--- a/step3_create_datamart.ipynb
+++ b/step3_create_datamart.ipynb
@@ -1,0 +1,229 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "b64de8d5-f762-4a96-be5a-546319518260",
+   "metadata": {},
+   "source": [
+    "# US Presidential Election Analysis: Electoral College, Popular Vote, or Both?\n",
+    "\n",
+    "## Objective\n",
+    "This notebook contains the third step in a larger effort to analyze historical US Presidential Election data. It focuses on building Data Mart objects that combine the data from steps 1 and 2 into object(s) that will power dashboard(s)\n",
+    "1. [ ] Create Data Mart object(s) from tables available in `elections` Postgres DB\n",
+    "2. [ ] Write DM object(s) to csv file(s) to import into Google Data Studio, Superset, or other BI tools\n",
+    "\n",
+    "### Notes\n",
+    "- I've been unable to connect my local Postgres database to Google Data Studio, due to an unknown network issue, so this notebook will write csv file(s) with the DM objects instead of writing the objects back into the Postgres database (where they can't be used, grrrrr)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "072626d4-6f8f-4739-98ad-144399b83ca4",
+   "metadata": {},
+   "source": [
+    "## 1. Setup"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "329ad39f-be1a-496e-9c72-0f8b7f49c696",
+   "metadata": {},
+   "source": [
+    "### 1.1 Import Modules"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "063a4ad5-948d-4254-9e59-9e76ce01071a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from db_tools import DBC\n",
+    "import getpass\n",
+    "import pandas as pd"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ddf2b32a-4deb-4a7a-bf4e-37a1463b2bbc",
+   "metadata": {},
+   "source": [
+    "### 1.2 Set Parameters "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 49,
+   "id": "7f568100-a52a-4cba-a75f-f913e519f6ab",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdin",
+     "output_type": "stream",
+     "text": [
+      " ·········\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Define parameters for database connection, schema name, table name, and column definitions\n",
+    "# Obfuscate password using getpass\n",
+    "db_config = {\n",
+    "    'user': 'postgres',\n",
+    "    'host': 'localhost',\n",
+    "    'port': '5432',\n",
+    "    'dbname': 'elections',\n",
+    "    'password': getpass.getpass()\n",
+    "}\n",
+    "# Data Warehouse schema\n",
+    "schema = 'dwh'\n",
+    "# Query that defines data mart object\n",
+    "dm_sql = f\"\"\"\n",
+    "select v.year as votes__year\n",
+    "    , v.state as votes__state\n",
+    "    , v.is_total as votes__is_total\n",
+    "    , v.total_electoral_votes\n",
+    "        as votes__total_electoral_votes\n",
+    "    , v.president_electoral_votes\n",
+    "        as votes__president_electoral_votes\n",
+    "    , v.president_electoral_rank\n",
+    "        as votes__president_electoral_rank\n",
+    "    , vs.region as votes__state__region\n",
+    "    , vs.division as votes__state__division\n",
+    "    , round((vs.area_land + vs.area_water) / 1e6, 2)\n",
+    "        as votes__state__area\n",
+    "    , c.name as candidate__name\n",
+    "    , c.party as candidate__party\n",
+    "    , c.party_2 as candidate__party_2\n",
+    "    , c.state as candidate__state\n",
+    "    , c.state_2 as candidate__state_2\n",
+    "from {schema}.votes v \n",
+    "left join {schema}.state vs on v.state = vs.state\n",
+    "join {schema}.candidate c on v.candidate_id = c.candidate_id \n",
+    "\"\"\"\n",
+    "csv_file = \"presidential_election_dm_object.csv\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "11255234-4f74-477a-ba6a-fd8dbb2539fc",
+   "metadata": {},
+   "source": [
+    "## 2. Create Data Mart Object as CSV file"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dd42dc75-b210-43d3-ae2b-0cb59a1ce4bb",
+   "metadata": {},
+   "source": [
+    "### 2.1 Define DB Connection"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 48,
+   "id": "2b4d5b88-db2c-4ff0-8cec-1c6ebdc76bce",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<class 'pandas.core.frame.DataFrame'>\n",
+      "RangeIndex: 4110 entries, 0 to 4109\n",
+      "Data columns (total 14 columns):\n",
+      " #   Column                            Non-Null Count  Dtype  \n",
+      "---  ------                            --------------  -----  \n",
+      " 0   votes__year                       4110 non-null   int64  \n",
+      " 1   votes__state                      4028 non-null   object \n",
+      " 2   votes__is_total                   4110 non-null   bool   \n",
+      " 3   votes__total_electoral_votes      4110 non-null   int64  \n",
+      " 4   votes__president_electoral_votes  4110 non-null   int64  \n",
+      " 5   votes__president_electoral_rank   4110 non-null   int64  \n",
+      " 6   votes__state__region              4028 non-null   float64\n",
+      " 7   votes__state__division            4028 non-null   float64\n",
+      " 8   votes__state__area                4028 non-null   float64\n",
+      " 9   candidate__name                   4110 non-null   object \n",
+      " 10  candidate__party                  3399 non-null   object \n",
+      " 11  candidate__party_2                234 non-null    object \n",
+      " 12  candidate__state                  4058 non-null   object \n",
+      " 13  candidate__state_2                259 non-null    object \n",
+      "dtypes: bool(1), float64(3), int64(4), object(6)\n",
+      "memory usage: 421.6+ KB\n"
+     ]
+    }
+   ],
+   "source": [
+    "dbc = DBC(db_config)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "53a95243-7b7b-45c6-b775-7efb7586dd70",
+   "metadata": {},
+   "source": [
+    "### 2.2 Build DM Object"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "140d44e6-9af5-4f1d-a80c-dc3c870b9a61",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_dm = dbc.select_query_to_df(dm_sql, close=True)\n",
+    "df_dm.info()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "38037c8f-3f05-492c-b395-4f1db761d4a8",
+   "metadata": {},
+   "source": [
+    "### 2.3 Write DM Object to CSV file"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 50,
+   "id": "ec4686ab-0593-4560-9640-0d643b087676",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_dm.to_csv(csv_file, index=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c7b37044-bddb-4961-9259-4d2dce286362",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This PR's notebook contains the third step in a larger effort to analyze historical US Presidential Election data. It focuses on building the base Data Mart (DM) object that combine the data from steps 1 and 2 into a core reporting object for the most common use cases of the voting data (e.g. dashboard charts):
1. [ ] Create Data Mart object(s) from tables available in `elections` Postgres DB
2. [ ] Write base DM object to `dm` schema in Postgres DB
3. [ ] Write base DM object csv file(s) to import into Google Data Studio, Superset, or other BI tools